### PR TITLE
Explicitly define version requirements for pymilvus

### DIFF
--- a/solutions/audio_similarity_search/requirements.txt
+++ b/solutions/audio_similarity_search/requirements.txt
@@ -1,4 +1,4 @@
-pymilvus
+pymilvus==1.1.0
 redis
 librosa
 ipython

--- a/solutions/image_similarity_search/requirements.txt
+++ b/solutions/image_similarity_search/requirements.txt
@@ -1,4 +1,4 @@
-pymilvus
+pymilvus==1.1.0
 redis
 torch
 torchvision

--- a/solutions/question_answering_system/requirements.txt
+++ b/solutions/question_answering_system/requirements.txt
@@ -1,5 +1,5 @@
 sentence_transformers
-pymilvus
+pymilvus==1.1.0
 psycopg2
 pandas
 numpy


### PR DESCRIPTION
A few of the bootcamp requirements.txt did not define a version requirement for pymilvus, causing issues if an outdated version of the package was already installed on the system. 