### PR TITLE
Stop printing out the first search result

### DIFF
--- a/solutions/video_similarity_search/object_detection/server/src/milvus_helpers.py
+++ b/solutions/video_similarity_search/object_detection/server/src/milvus_helpers.py
@@ -96,7 +96,7 @@ class MilvusHelper:
             search_params = {"metric_type": METRIC_TYPE, "params": {"nprobe": 16}}
             # data = [vectors]
             res = self.collection.search(vectors, anns_field="embedding", param=search_params, limit=top_k)
-            print(res[0])
+            #print(res[0])
             LOGGER.debug("Successfully search in collection: {}".format(res))
             return res
         except Exception as e:


### PR DESCRIPTION
Signed-off-by: Jael Gu <mengjia.gu@zilliz.com>

Comment one line in milvus_helper.py of video object detection, to make it not print out 1st  search result each time.