### PR TITLE
Add row count after all npy inserts are done

### DIFF
--- a/benchmark_test/scripts/load.py
+++ b/benchmark_test/scripts/load.py
@@ -87,6 +87,7 @@ def npy_to_milvus(collection_name, client):
         total_insert_time = total_insert_time + time.time() - time_add_start
         print(filename, "insert rows", len(ids), " insert milvus time: ", time.time() - time_add_start)
         collection_rows = collection_rows + len(ids)
+    client.count(collection_name)
     print("total insert time: ", total_insert_time)
 
 


### PR DESCRIPTION
Signed-off-by: Jael Gu <mengjia.gu@zilliz.com>

Add row count after all npy inserts are done so that logs will have row count after the last insert.