### PR TITLE
Add row count after all bvec inserts are done

### DIFF
--- a/benchmark_test/scripts/load.py
+++ b/benchmark_test/scripts/load.py
@@ -117,6 +117,7 @@ def bvecs_to_milvus(collection_name, client):
         total_insert_time = total_insert_time + time.time() - time_add_start
         count = count + 1
         collection_rows = collection_rows + len(ids)
+    client.count(collection_name)
     print("total insert time: {}".format(total_insert_time))
 
 


### PR DESCRIPTION
Signed-off-by: Jael Gu <mengjia.gu@zilliz.com>

Add row count after all bvec inserts are done so that logs will have row count after the last insert.