### PR TITLE
Reverse-image-search: change encoder to towhee

### DIFF
--- a/solutions/reverse_image_search/quick_deploy/server/src/encode.py
+++ b/solutions/reverse_image_search/quick_deploy/server/src/encode.py
@@ -1,26 +1,16 @@
 import numpy as np
-from tensorflow.keras.applications.resnet50 import ResNet50
-from tensorflow.keras.applications.resnet50 import preprocess_input as preprocess_input_resnet50
-from tensorflow.keras.preprocessing import image
 from numpy import linalg as LA
+from towhee import pipeline
+from PIL import Image
 
 
 class Resnet50:
     def __init__(self):
-        self.input_shape = (224, 224, 3)
-        self.weight = 'imagenet'
-        self.pooling = 'max'
-        self.model_resnet50 = ResNet50(weights='imagenet',
-                                       input_shape=(self.input_shape[0], self.input_shape[1], self.input_shape[2]),
-                                       pooling=self.pooling, include_top=False)
-        self.model_resnet50.predict(np.zeros((1, 224, 224, 3)))
+        self.embedding_pipeline = pipeline('image-embedding')
 
     def resnet50_extract_feat(self, img_path):
-        # Return the normalized embedding([[list]]) of the images
-        img = image.load_img(img_path, target_size=(self.input_shape[0], self.input_shape[1]))
-        img = image.img_to_array(img)
-        img = np.expand_dims(img, axis=0)
-        img = preprocess_input_resnet50(img)
-        feat = self.model_resnet50.predict(img)
-        norm_feat = feat[0] / LA.norm(feat[0])
-        return norm_feat.tolist()
+        # Return the normalized embedding([[list]]) of image
+        img = Image.open(img_path)
+        (feat,) = self.embedding_pipeline(img)
+        norm_feat = feat / LA.norm(feat)
+        return norm_feat.tolist()[0]


### PR DESCRIPTION
Signed-off-by: Jael Gu <mengjia.gu@zilliz.com>

Use towhee image-embedding pipeline in encode.py for quick-deploy.