### PR TITLE
fix audio-client healthprobe

### DIFF
--- a/solutions/audio_similarity_search/quick_deploy/audiosearch-docker-compose.yaml
+++ b/solutions/audio_similarity_search/quick_deploy/audiosearch-docker-compose.yaml
@@ -90,7 +90,7 @@ services:
     ports:
       - "801:80"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:801"]
+      test: ["CMD", "curl", "-f", "http://localhost/"]
       interval: 30s
       timeout: 20s
       retries: 3

--- a/solutions/audio_similarity_search/quick_deploy/client/Dockerfile
+++ b/solutions/audio_similarity_search/quick_deploy/client/Dockerfile
@@ -24,8 +24,8 @@ WORKDIR /usr/share/nginx/html
 COPY ./env.sh .
 COPY .env .
 
-# Add bash
-RUN apk add --no-cache bash
+# Add bash, curl
+RUN apk add --no-cache bash curl
 
 # Make our shell script executable
 RUN chmod +x env.sh


### PR DESCRIPTION
The related issue #992

According to docker-compose [documentation](https://docs.docker.com/engine/reference/builder/#healthcheck)  health-check commands run inside the container:

> check container health by running a command inside the container

The current implementation seem to assume they run on the host computer, and therefore fails. 
To fix, added curl command installation into the container, and updated the health check command to work from within the container.

:tada:
