### PR TITLE
fix issue with small audio files in audio similarity search

### DIFF
--- a/solutions/audio_similarity_search/quick_deploy/server/src/operations/load.py
+++ b/solutions/audio_similarity_search/quick_deploy/server/src/operations/load.py
@@ -27,6 +27,8 @@ def extract_features(audio_dir):
         cache['total'] = total
         for i, audio_path in enumerate(audio_list):
             norm_feat = get_audio_embedding(audio_path)
+            if norm_feat is None:
+                continue
             feats.append(norm_feat)
             names.append(audio_path.encode())
             cache['current'] = i + 1


### PR DESCRIPTION
The reference to a related issue #994.
  
The proposed change skips processing of the embedding results equal to None as they are returned, therefore allowing for the audio-webserver to index the audio files with valid longer duration.

:tada: