### PR TITLE
fix molecular search web client healthcheck

### DIFF
--- a/solutions/molecular_similarity_search/quick_deploy/client/Dockerfile
+++ b/solutions/molecular_similarity_search/quick_deploy/client/Dockerfile
@@ -24,8 +24,8 @@ WORKDIR /usr/share/nginx/html
 COPY ./env.sh .
 COPY .env .
 
-# Add bash
-RUN apk add --no-cache bash
+# Add bash, curl
+RUN apk add --no-cache bash curl
 
 # Make our shell script executable
 RUN chmod +x env.sh

--- a/solutions/molecular_similarity_search/quick_deploy/molsearch-docker-compose.yaml
+++ b/solutions/molecular_similarity_search/quick_deploy/molsearch-docker-compose.yaml
@@ -90,7 +90,7 @@ services:
     ports:
       - "801:80"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:801"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
       interval: 30s
       timeout: 20s
       retries: 3


### PR DESCRIPTION
The related issue is #980 

- [ ] A description of the changes proposed in the pull request.

I fixed the port in healthcheck probe and added curl to the container so the health check will work.

:tada:
