### PR TITLE
add support for multiple audio file formats

### DIFF
--- a/solutions/audio_similarity_search/quick_deploy/server/Dockerfile
+++ b/solutions/audio_similarity_search/quick_deploy/server/Dockerfile
@@ -1,14 +1,16 @@
 FROM python:3.7-slim-buster
 
 RUN apt update
-RUN apt install -y libsndfile1-dev wget
+RUN apt install -y libsndfile1-dev wget ffmpeg
 RUN pip3 install --upgrade pip
 
 WORKDIR /app/src
-COPY . /app
+COPY requirements.txt /app/requirements.txt
 
 RUN pip3 install -r /app/requirements.txt
 
 RUN mkdir -p /tmp/audio-data
+
+COPY . /app
 
 CMD python3 main.py

--- a/solutions/audio_similarity_search/quick_deploy/server/src/operations/load.py
+++ b/solutions/audio_similarity_search/quick_deploy/server/src/operations/load.py
@@ -9,12 +9,10 @@ from logs import LOGGER
 
 
 def get_audios(path):
-    # Get the path to the image
-    audios = []
-    for f in os.listdir(path):
-        if f.endswith('.wav'):
-            audios.append(os.path.join(path, f))
-    return audios
+    # List all wav and aif files recursively under the path folder.
+    supported_formats = [".wav", ".aif", ".mp3", ".ogg", ".flac", ".m4a"]
+    return [ item for sublist in [ [ os.path.join(dir, file) for file in files ] for dir, _, files in list(os.walk(path)) ] 
+        for item in sublist if os.path.splitext(item)[1] in supported_formats ]
 
 def extract_features(audio_dir):
     # Get the vector of audio


### PR DESCRIPTION
This is in relation to feature request: #999

Changes:

Update of Dockerfile so the container will contain ffmpeg (requirement for libros to load variety of sound formats)
Allow for processing of all files below given folder at arbitrary sub-folder depth.

 :tada:
