### PR TITLE
Fix the problem of failed loading of collection before its indexing

### DIFF
--- a/solutions/nlp/text_search_engine/quick_deploy/server/src/milvus_helpers.py
+++ b/solutions/nlp/text_search_engine/quick_deploy/server/src/milvus_helpers.py
@@ -59,7 +59,6 @@ class MilvusHelper:
             data = [vectors]
             mr = self.collection.insert(data)
             ids =  mr.primary_keys
-            self.collection.load()
             LOGGER.debug(f"Insert vectors to Milvus in collection: {collection_name} with {len(vectors)} rows")
             return ids
         except Exception as e:
@@ -80,6 +79,15 @@ class MilvusHelper:
                 raise Exception(status.message)
         except Exception as e:
             LOGGER.error(f"Failed to create index: {e}")
+            sys.exit(1)
+
+    def load(self, collection_name):
+        # Load Milvus collection into RAM
+        try:
+            self.set_collection(collection_name)
+            self.collection.load()
+        except Exception as e:
+            LOGGER.error(f"Failed to load data into RAM: {e}")
             sys.exit(1)
 
     def delete_collection(self, collection_name):

--- a/solutions/nlp/text_search_engine/quick_deploy/server/src/operations/load.py
+++ b/solutions/nlp/text_search_engine/quick_deploy/server/src/operations/load.py
@@ -37,6 +37,10 @@ def do_load(collection_name, file_dir, model, milvus_client, mysql_cli):
     title_data, text_data, sentence_embeddings = extract_features(file_dir, model)
     ids = milvus_client.insert(collection_name, sentence_embeddings)
     milvus_client.create_index(collection_name)
+
+    # Load the collection data into RAM just AFTER creating index
+    milvus_client.load(collection_name)
+
     mysql_cli.create_mysql_table(collection_name)
     mysql_cli.load_data_to_mysql(collection_name, format_data(ids, title_data, text_data))
     return len(ids)


### PR DESCRIPTION
- Problem: same error as in [milvus-io/milvus/#21932](https://github.com/milvus-io/milvus/issues/21932#issue-1567449907) that is `BaseException: (code=1, message=index doesn't exist...`
- Solution: Adding a separate load method for MilvusHelper to make it possible to run it out of the `insert` method may lead to an error because it is before indexing. So, we load data just when needed.
