### PR TITLE
Add devcontainer for easy demo/dev of notebooks via Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "cpus": 4
   },
   "waitFor": "onCreateCommand",
-  "updateContentCommand": "python -m pip install -r .devcontainer/requirements.txt",
+  "updateContentCommand": "pip install -r .devcontainer/requirements.txt",
   "postCreateCommand": "",
   "customizations": {
     "codespaces": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "hostRequirements": {
+    "cpus": 4
+  },
+  "waitFor": "onCreateCommand",
+  "updateContentCommand": "python -m pip install -r .devcontainer/requirements.txt",
+  "postCreateCommand": "",
+  "customizations": {
+    "codespaces": {
+      "openFiles": [
+        "notebooks/llms/langchain/lc_vectorstore_conv_mem.ipynb",
+        "notebooks/llms/llamaindex/multi_doc_qa.ipynb",
+        "notebooks/text/white_house_speeches.ipynb",
+        "notebooks/vision/reverse_painting_search.ipynb"
+      ]
+    },
+    "vscode": {
+      "extensions": [
+        "ms-toolsai.jupyter",
+        "ms-python.python"
+      ]
+    }
+  }
+}

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,0 +1,14 @@
+ipykernel
+llama-index
+nltk
+milvus
+pymilvus==2.2.5
+torch
+torchvision
+tqdm
+sentence-transformers
+gdown
+langchain
+openai
+python-dotenv
+requests


### PR DESCRIPTION
Add support to enable users to efficiently run a notebook directly in GitHub Codespaces. For the fastest experience (cached Python requirements), turn on [prebuilds](https://docs.github.com/en/codespaces/prebuilding-your-codespaces).

@ytang07 this may be incomplete; having some trouble getting lzma to surface to the notebook in 3.10 (even using pip install backports.lzma), but should get you 90% there 😄 