### PR TITLE
Update recommender_system.ipynb

### DIFF
--- a/solutions/nlp/recommender_system/recommender_system.ipynb
+++ b/solutions/nlp/recommender_system/recommender_system.ipynb
@@ -388,7 +388,7 @@
     "        pprint(batch)\n",
     "        break\n",
     "\n",
-    "collection.insert(movie_dict)\n",
+    "collection.insert(batch)\n",
     "print(\"Final batch completed\")\n",
     "print(\"Finished with {} embeddings\".format(j))"
    ]


### PR DESCRIPTION
During adding the batch to the collection, only the last movie_dict is being added, what if the j reaches up to 4 but never enters the if j%5==0 condition, then we want all 4 entries in the batch to be loaded to the collection, not just the last movie_dict.

<!-- If there are many commits but not yours, please re-Fork Bootcamp repo and submit a PR again.-->

- [ ] A reference to a related issue in your repository.
  
  Each PR is related to an issue, and you need to list that issue.

- [x] A description of the changes proposed in the pull request.

  A brief introduction to this PR.

- [ ] Add delight to the experience when all tasks are complete :tada:
