### PR TITLE
Cast MODEL_DIM to Integer

### DIFF
--- a/bootcamp/tutorials/quickstart/apps/image_search_with_milvus/insert.py
+++ b/bootcamp/tutorials/quickstart/apps/image_search_with_milvus/insert.py
@@ -23,7 +23,7 @@ milvus_client = get_milvus_client(uri=MILVUS_ENDPOINT, token=MILVUS_TOKEN)
 
 # Create collection
 create_collection(
-    milvus_client=milvus_client, collection_name=COLLECTION_NAME, dim=MODEL_DIM
+    milvus_client=milvus_client, collection_name=COLLECTION_NAME, dim=int(MODEL_DIM)
 )
 
 # Load images from directory and generate embeddings


### PR DESCRIPTION
The os.getenv() call returns string, and create_collection wants an int. Casting MODEL_DIM to int so it is compliant with create_collection.

<!-- If there are many commits but not yours, please re-Fork Bootcamp repo and submit a PR again.-->

- [X] A reference to a related issue in your repository.
  
1467

- [X] A description of the changes proposed in the pull request.

Cast MODEL_DIM to int, to prevent a crash when MODEL_DIM is an string

- [ ] Add delight to the experience when all tasks are complete :tada:
