### PR TITLE
fix: correct typo "Lanage" to "Language" in tutorials/quickstart/build_RAG_with_milvus.ipynb

### DIFF
--- a/bootcamp/tutorials/quickstart/build_RAG_with_milvus.ipynb
+++ b/bootcamp/tutorials/quickstart/build_RAG_with_milvus.ipynb
@@ -431,7 +431,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Define system and user prompts for the Lanage Model. This prompt is assembled with the retrieved documents from Milvus."
+    "Define system and user prompts for the Language Model. This prompt is assembled with the retrieved documents from Milvus."
    ]
   },
   {


### PR DESCRIPTION
Corrected a typo in the word "Language". The previous spelling "Lanage" has been fixed to "Language" for clarity.
