### PR TITLE
Update use_ColPali_with_milvus.ipynb

### DIFF
--- a/bootcamp/tutorials/quickstart/use_ColPali_with_milvus.ipynb
+++ b/bootcamp/tutorials/quickstart/use_ColPali_with_milvus.ipynb
@@ -40,10 +40,10 @@
    "outputs": [],
    "source": [
     "!pip install pdf2image\n",
-    "!pip pymilvus\n",
+    "!pip install pymilvus\n",
     "!pip install colpali_engine\n",
     "!pip install tqdm\n",
-    "!pip instal pillow"
+    "!pip install pillow"
    ]
   },
   {


### PR DESCRIPTION
Fix two failures:
pip pymilvus is missing the install keyword
pip instal pillow has a typo in "install"
Updated to:
pip install pymilvus 
pip install pillow
