### PR TITLE
Add Slack badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <a href="https://github.com/milvus-io/bootcamp/blob/master/LICENSE"><img height="20" src="https://img.shields.io/github/license/milvus-io/bootcamp" alt="license"/></a>
   <a href="https://milvus.io"><img src="https://img.shields.io/badge/milvus-blue" alt="milvus"/></a>
   <a href="https://cloud.zilliz.com/signup?utm_source=partner&utm_medium=referral&utm_campaign=2024-11-04_web_github-readme_global"><img src="https://img.shields.io/badge/zilliz-green" alt="fully-managed-milvus"/></a>
-  <a href="https://milvus.io/slack"><img height="20" src="https://img.shields.io/badge/Slack-%234A154B.svg?style=for-the-badge&logo=slack&logoColor=white" alt="slack"/></a>
+  <a href="https://milvus.io/slack"><img src="https://img.shields.io/badge/Slack-%234A154B.svg?style=flat&logo=slack&logoColor=white" alt="slack"/></a>
   <a href="https://discord.gg/mKc3R95yE5"><img height="20" src="https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badge&logo=discord&logoColor=white" alt="discord"/></a>
   <a href="https://x.com/milvusio"><img src="https://img.shields.io/twitter/follow/milvusio" alt="twitter"/></a>
 </div>


### PR DESCRIPTION
This pull request adds a Slack badge to the `README.md` for users to find and join the Milvus Slack community. 
