### PR TITLE
Add RAG with Milvus and Exa integration notebook

### DIFF
--- a/integration/build_RAG_with_milvus_and_exa.ipynb
+++ b/integration/build_RAG_with_milvus_and_exa.ipynb
@@ -4,21 +4,7 @@
    "cell_type": "markdown",
    "id": "dbf42cd9-f7d0-4dac-9938-d82baa05b6e9",
    "metadata": {},
-   "source": [
-    "<a href=\"https://colab.research.google.com/github/milvus-io/bootcamp/blob/master/integration/build_RAG_with_milvus_and_exa.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>   <a href=\"https://github.com/milvus-io/bootcamp/blob/master/integration/build_RAG_with_milvus_and_exa.ipynb\" target=\"_blank\">\n",
-    "    <img src=\"https://img.shields.io/badge/View%20on%20GitHub-555555?style=flat&logo=github&logoColor=white\" alt=\"GitHub Repository\"/>\n",
-    "</a>\n",
-    "\n",
-    "# Building a Dual-Source RAG Agent with Exa and Milvus\n",
-    "\n",
-    "This tutorial demonstrates how to build an agent that searches both **the public web** (via [Exa](https://exa.ai/)) and **a private knowledge base** (via [Milvus](https://milvus.io/)), then synthesizes a unified answer. The agent uses OpenAI's function calling to automatically decide which source to query based on the user's question.\n",
-    "\n",
-    "[Exa](https://exa.ai/) is a search API designed for AI applications. Unlike traditional keyword-based search engines, Exa supports semantic (neural) search — you describe what you want in natural language and it understands your intent. It also provides content extraction, highlights, and category-based filtering. [Milvus](https://milvus.io/) is an open-source vector database built for scalable similarity search. By combining them with an LLM agent, you can build a system that retrieves both internal proprietary data and up-to-date web information in a single workflow.\n",
-    "\n",
-    "## Prerequisites\n",
-    "\n",
-    "Before running this notebook, make sure you have the following dependencies installed:"
-   ]
+   "source": "<a href=\"https://colab.research.google.com/github/milvus-io/bootcamp/blob/master/integration/build_RAG_with_milvus_and_exa.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>   <a href=\"https://github.com/milvus-io/bootcamp/blob/master/integration/build_RAG_with_milvus_and_exa.ipynb\" target=\"_blank\">\n    <img src=\"https://img.shields.io/badge/View%20on%20GitHub-555555?style=flat&logo=github&logoColor=white\" alt=\"GitHub Repository\"/>\n</a>\n\n# Building a Dual-Source RAG Agent with Exa and Milvus\n\nThis tutorial demonstrates how to build an agent that searches both **the public web** (via [Exa](https://exa.ai/)) and **a private knowledge base** (via [Milvus](https://milvus.io/)), then synthesizes a unified answer. The agent uses OpenAI's function calling to automatically decide which source to query based on the user's question.\n\n[Exa](https://exa.ai/) is a search API designed for AI applications, which is proudly powered by [Zilliz Cloud](https://zilliz.com/cloud) (fully managed Milvus). Unlike traditional keyword-based search engines, Exa supports semantic (neural) search — you describe what you want in natural language and it understands your intent. It also provides content extraction, highlights, and category-based filtering. [Milvus](https://milvus.io/) is an open-source vector database built for scalable similarity search. By combining them with an LLM agent, you can build a system that retrieves both internal proprietary data and up-to-date web information in a single workflow.\n\n## Prerequisites\n\nBefore running this notebook, make sure you have the following dependencies installed:"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

- Add a new integration notebook demonstrating how to build a dual-source RAG agent using Exa (web search) and Milvus (private knowledge base)
- The agent uses OpenAI function calling to automatically route queries to the appropriate source
- Covers Exa features including semantic search, category filtering, content extraction, and similar article discovery

## Test plan

- [x] Notebook executes end-to-end successfully
- [x] All Exa search results return valid content
- [x] Milvus vector search retrieval works correctly
- [x] Agent correctly routes queries to private KB, web, or both sources