### PR TITLE
feat: add AG2 multi-agent RAG integration with Milvus

### DIFF
--- a/integration/ag2/ag2_multiagent_rag_with_milvus.ipynb
+++ b/integration/ag2/ag2_multiagent_rag_with_milvus.ipynb
@@ -1,0 +1,314 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1f7e235-7d3a-4e5b-9b8e-6c4d2f1a3b5c",
+   "metadata": {},
+   "source": "<a href=\"https://colab.research.google.com/github/milvus-io/bootcamp/blob/master/integration/ag2/ag2_multiagent_rag_with_milvus.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>   <a href=\"https://github.com/milvus-io/bootcamp/blob/master/integration/ag2/ag2_multiagent_rag_with_milvus.ipynb\" target=\"_blank\">\n    <img src=\"https://img.shields.io/badge/View%20on%20GitHub-555555?style=flat&logo=github&logoColor=white\" alt=\"GitHub Repository\"/>\n</a>\n\n# AG2 Multi-Agent RAG with Milvus\n\nThis notebook demonstrates how to use [AG2](https://ag2.ai/) (formerly AutoGen) multi-agent conversations with [Milvus](https://milvus.io/) as the vector store for Retrieval-Augmented Generation (RAG).\n\nIn this example, two AG2 agents collaborate:\n- **Research Agent**: Retrieves relevant documents from Milvus via vector search\n- **Analyst Agent**: Synthesizes retrieved information into comprehensive answers\n\n## Prerequisites\n\nBefore running this notebook, make sure you have the following dependencies installed:"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3e5c8a1-4d2f-4a7b-8c9e-1f3d5a6b7c8e",
+   "metadata": {},
+   "outputs": [],
+   "source": "! pip install -U \"ag2[openai]>=0.11.4,<1.0\" pymilvus \"pymilvus[milvus_lite]\" openai"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5d4e3f2-6a1b-4c8d-9e7f-2a5b3d4c6e8a",
+   "metadata": {},
+   "source": [
+    "> If you are using Google Colab, to enable dependencies just installed, you may need to **restart the runtime** (click on the \"Runtime\" menu at the top of the screen, and select \"Restart session\" from the dropdown menu).\n",
+    "\n",
+    "We will use the models from OpenAI. You should prepare the [api key](https://platform.openai.com/docs/quickstart) `OPENAI_API_KEY` as an environment variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6e7f8a9-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\nos.environ[\"OPENAI_API_KEY\"] = \"sk-***********\"\n\nfrom openai import OpenAI\n\nopenai_client = OpenAI(api_key=os.environ[\"OPENAI_API_KEY\"])\n\n\ndef embed_texts(input_texts):\n    \"\"\"Generate embeddings using OpenAI.\"\"\"\n    response = openai_client.embeddings.create(\n        model=\"text-embedding-3-small\", input=input_texts\n    )\n    return [item.embedding for item in response.data]"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1f2a3b4-5c6d-7e8f-9a0b-1c2d3e4f5a6b",
+   "metadata": {},
+   "source": [
+    "## Prepare Sample Data\n",
+    "\n",
+    "We'll use a small set of sample documents to demonstrate the RAG pipeline. In production, you would load your own documents (PDFs, web pages, etc.)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3a4b5c6-7d8e-9f0a-1b2c-3d4e5f6a7b8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sample documents about AI topics\n",
+    "documents = [\n",
+    "    {\n",
+    "        \"text\": (\n",
+    "            \"Retrieval-Augmented Generation (RAG) is a technique that combines \"\n",
+    "            \"information retrieval with language model generation. It first retrieves \"\n",
+    "            \"relevant documents from a knowledge base, then uses them as context for \"\n",
+    "            \"generating accurate, grounded responses. RAG reduces hallucination and \"\n",
+    "            \"enables models to access up-to-date information beyond their training data.\"\n",
+    "        ),\n",
+    "        \"source\": \"ai_concepts.md\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"text\": (\n",
+    "            \"Vector databases store data as high-dimensional vectors (embeddings) \"\n",
+    "            \"and enable fast similarity search. Milvus is a leading open-source vector \"\n",
+    "            \"database that supports billions of vectors with millisecond search latency. \"\n",
+    "            \"It uses indexing algorithms like HNSW and IVF for efficient approximate \"\n",
+    "            \"nearest neighbor (ANN) search.\"\n",
+    "        ),\n",
+    "        \"source\": \"vector_databases.md\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"text\": (\n",
+    "            \"Multi-agent systems use multiple AI agents that collaborate to solve \"\n",
+    "            \"complex tasks. Each agent can have specialized roles, tools, and knowledge. \"\n",
+    "            \"AG2 (formerly AutoGen) is a popular framework for building multi-agent \"\n",
+    "            \"conversations where agents can use tools, write code, and coordinate \"\n",
+    "            \"through structured dialogue patterns.\"\n",
+    "        ),\n",
+    "        \"source\": \"multi_agent_systems.md\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"text\": (\n",
+    "            \"Embedding models convert text into dense numerical vectors that \"\n",
+    "            \"capture semantic meaning. Similar texts produce similar vectors, enabling \"\n",
+    "            \"semantic search. Popular embedding models include OpenAI text-embedding-3-small, \"\n",
+    "            \"sentence-transformers, and BGE models. The choice of embedding model \"\n",
+    "            \"significantly impacts retrieval quality in RAG systems.\"\n",
+    "        ),\n",
+    "        \"source\": \"embeddings.md\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"text\": (\n",
+    "            \"Chunking is the process of splitting documents into smaller pieces \"\n",
+    "            \"for embedding and retrieval. Common strategies include fixed-size chunking, \"\n",
+    "            \"recursive character splitting, and semantic chunking. Optimal chunk size \"\n",
+    "            \"depends on the use case: 256-512 tokens for precise retrieval, 1000+ tokens \"\n",
+    "            \"for broader context. Overlap between chunks helps preserve context.\"\n",
+    "        ),\n",
+    "        \"source\": \"chunking_strategies.md\",\n",
+    "    },\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7b8c9d0-1e2f-3a4b-5c6d-7e8f9a0b1c2d",
+   "metadata": {},
+   "source": "## Set Up Milvus Vector Store\n\nWe'll use **Milvus Lite** which runs entirely in-process — no Docker or server needed.\n\n> - Setting the `uri` as a local file, e.g.`./ag2_milvus_demo.db`, is the most convenient method, as it automatically utilizes [Milvus Lite](https://milvus.io/docs/milvus_lite.md) to store all data in this file.\n> - If you have large scale of data, you can set up a more performant Milvus server on [docker or kubernetes](https://milvus.io/docs/quickstart.md). In this setup, please use the server uri, e.g.`http://localhost:19530`, as your `uri`.\n> - If you want to use [Zilliz Cloud](https://zilliz.com/cloud), the fully managed cloud service for Milvus, adjust the `uri` and `token`, which correspond to the [Public Endpoint and Api key](https://docs.zilliz.com/docs/on-zilliz-cloud-console#free-cluster-details) in Zilliz Cloud."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8c9d0e1-2f3a-4b5c-6d7e-8f9a0b1c2d3e",
+   "metadata": {},
+   "outputs": [],
+   "source": "from pymilvus import MilvusClient\n\n# Generate embeddings for all documents\ntexts = [doc[\"text\"] for doc in documents]\nembeddings = embed_texts(texts)\ndim = len(embeddings[0])\nprint(f\"Embedding dimension: {dim}\")\n\n# Connect to Milvus Lite (in-process, no server needed)\nmilvus_client = MilvusClient(\"./ag2_milvus_demo.db\")\n\ncollection_name = \"ag2_rag_collection\"\n\n# Drop collection if it exists (for re-running)\nif milvus_client.has_collection(collection_name):\n    milvus_client.drop_collection(collection_name)\n\n# Create collection\nmilvus_client.create_collection(\n    collection_name=collection_name,\n    dimension=dim,\n)\n\n# Insert documents\ndata = [\n    {\n        \"id\": i,\n        \"vector\": embeddings[i],\n        \"text\": documents[i][\"text\"],\n        \"source\": documents[i][\"source\"],\n    }\n    for i in range(len(documents))\n]\n\nmilvus_client.insert(collection_name=collection_name, data=data)\nprint(f\"Inserted {len(data)} documents into Milvus collection '{collection_name}'\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9d0e1f2-3a4b-5c6d-7e8f-9a0b1c2d3e4f",
+   "metadata": {},
+   "source": [
+    "## Define Milvus Search Function\n",
+    "\n",
+    "Create a search function that AG2 agents will use as a tool to retrieve relevant documents from the Milvus collection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0e1f2a3-4b5c-6d7e-8f9a-0b1c2d3e4f5a",
+   "metadata": {},
+   "outputs": [],
+   "source": "def search_milvus(query: str, top_k: int = 3) -> str:\n    \"\"\"\n    Search Milvus collection for relevant documents.\n\n    Args:\n        query: Search query string.\n        top_k: Number of results to return.\n\n    Returns:\n        Formatted string with retrieved documents and sources.\n    \"\"\"\n    # Encode query\n    query_embedding = embed_texts([query])\n\n    # Search Milvus\n    results = milvus_client.search(\n        collection_name=collection_name,\n        data=query_embedding,\n        limit=top_k,\n        output_fields=[\"text\", \"source\"],\n    )\n\n    # Format results\n    formatted = []\n    for i, hit in enumerate(results[0], 1):\n        source = hit[\"entity\"][\"source\"]\n        text = hit[\"entity\"][\"text\"]\n        score = hit[\"distance\"]\n        formatted.append(f\"[{i}] Source: {source} (similarity: {score:.4f})\\n{text}\")\n\n    return (\n        \"\\n\\n---\\n\\n\".join(formatted) if formatted else \"No relevant documents found.\"\n    )\n\n\n# Test the search function\nprint(search_milvus(\"What is RAG?\"))"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1f2a3b4-5c6d-7e8f-9a0b-1c2d3e4f5a6c",
+   "metadata": {},
+   "source": [
+    "## Set Up AG2 Multi-Agent System\n",
+    "\n",
+    "Create AG2 agents that collaborate to answer questions using Milvus retrieval:\n",
+    "\n",
+    "1. **Research Agent** — Uses the `search_milvus` tool to find relevant documents\n",
+    "2. **Analyst Agent** — Synthesizes retrieved information into a final answer\n",
+    "3. **User Proxy** — Orchestrates the conversation and executes tool calls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2a3b4c5-6d7e-8f9a-0b1c-2d3e4f5a6b7c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from autogen import (\n",
+    "    AssistantAgent,\n",
+    "    GroupChat,\n",
+    "    GroupChatManager,\n",
+    "    LLMConfig,\n",
+    "    UserProxyAgent,\n",
+    ")\n",
+    "\n",
+    "# AG2 LLM Configuration\n",
+    "llm_config = LLMConfig(\n",
+    "    {\n",
+    "        \"model\": \"gpt-4o-mini\",\n",
+    "        \"api_key\": os.environ[\"OPENAI_API_KEY\"],\n",
+    "        \"api_type\": \"openai\",\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "# Create agents\n",
+    "researcher = AssistantAgent(\n",
+    "    name=\"researcher\",\n",
+    "    system_message=(\n",
+    "        \"You are a research agent. When asked a question, use the search_documents \"\n",
+    "        \"tool to retrieve relevant documents from the knowledge base. Present \"\n",
+    "        \"your findings clearly with source references. If results are insufficient, \"\n",
+    "        \"try rephrasing your search query.\"\n",
+    "    ),\n",
+    "    llm_config=llm_config,\n",
+    ")\n",
+    "\n",
+    "analyst = AssistantAgent(\n",
+    "    name=\"analyst\",\n",
+    "    system_message=(\n",
+    "        \"You are an analyst. Based on the researcher's findings, synthesize the \"\n",
+    "        \"information into a comprehensive, well-structured answer. Always reference \"\n",
+    "        \"the source documents. End with TERMINATE when done.\"\n",
+    "    ),\n",
+    "    llm_config=llm_config,\n",
+    ")\n",
+    "\n",
+    "user_proxy = UserProxyAgent(\n",
+    "    name=\"user_proxy\",\n",
+    "    human_input_mode=\"NEVER\",\n",
+    "    max_consecutive_auto_reply=10,\n",
+    "    code_execution_config=False,\n",
+    "    is_termination_msg=lambda x: x.get(\"content\", \"\")\n",
+    "    and \"TERMINATE\" in x.get(\"content\", \"\"),\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Register Milvus search as AG2 tool\n",
+    "@user_proxy.register_for_execution()\n",
+    "@researcher.register_for_llm(\n",
+    "    description=(\n",
+    "        \"Search the Milvus vector database for relevant documents. \"\n",
+    "        \"Returns document chunks with similarity scores and source references. \"\n",
+    "        \"Use specific search queries for best results.\"\n",
+    "    )\n",
+    ")\n",
+    "def search_documents(query: str, top_k: int = 3) -> str:\n",
+    "    \"\"\"Search Milvus for relevant documents.\"\"\"\n",
+    "    return search_milvus(query, top_k)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3b4c5d6-7e8f-9a0b-1c2d-3e4f5a6b7c8d",
+   "metadata": {},
+   "source": [
+    "## Run the Multi-Agent Conversation\n",
+    "\n",
+    "Now we set up a GroupChat where the agents collaborate, and ask a question that requires searching the knowledge base."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up GroupChat\n",
+    "group_chat = GroupChat(\n",
+    "    agents=[user_proxy, researcher, analyst],\n",
+    "    messages=[],\n",
+    "    max_round=12,\n",
+    ")\n",
+    "\n",
+    "manager = GroupChatManager(\n",
+    "    groupchat=group_chat,\n",
+    "    llm_config=llm_config,\n",
+    ")\n",
+    "\n",
+    "# Run the conversation\n",
+    "user_proxy.run(\n",
+    "    manager,\n",
+    "    message=(\n",
+    "        \"What is RAG and how does it work with vector databases? \"\n",
+    "        \"Also explain how multi-agent systems can improve RAG quality.\"\n",
+    "    ),\n",
+    ").process()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f",
+   "metadata": {},
+   "source": [
+    "## Cleanup\n",
+    "\n",
+    "Remove the Milvus Lite database file created during this demo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6e7f8a9-0b1c-2d3e-4f5a-6b7c8d9e0f1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if os.path.exists(\"./ag2_milvus_demo.db\"):\n",
+    "    os.remove(\"./ag2_milvus_demo.db\")\n",
+    "    print(\"Cleaned up Milvus Lite database.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b",
+   "metadata": {},
+   "source": "## Summary\n\nIn this tutorial, we built a multi-agent RAG system using AG2 and Milvus. The Research Agent retrieves relevant documents from Milvus via vector search, and the Analyst Agent synthesizes the findings into a comprehensive answer.\n\n### Key Components\n\n| Component | Role |\n|-----------|------|\n| **Milvus** | Vector storage and similarity search |\n| **OpenAI Embeddings** | Text-to-vector conversion |\n| **AG2 UserProxy** | Orchestrates conversation, executes tools |\n| **AG2 Research Agent** | Calls `search_documents` tool |\n| **AG2 Analyst Agent** | Synthesizes findings into final answer |\n\n### Next Steps\n\n- Scale up with more documents and a production Milvus deployment\n- Add more specialized agents (fact-checker, summarizer, etc.)\n- Use Milvus hybrid search (vector + BM25) for better retrieval\n- Add metadata filtering for domain-specific queries"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Add an integration notebook for [AG2](https://ag2.ai/) (formerly AutoGen), a multi-agent conversation framework.

- `integration/ag2/ag2_multiagent_rag_with_milvus.ipynb` — Complete notebook

## How it works

1. Documents are embedded using **OpenAI embeddings** and stored in **Milvus** (using Milvus Lite)
2. **AG2 Research Agent** uses a registered `search_documents` tool to query Milvus
3. **AG2 Analyst Agent** synthesizes retrieved information into grounded answers
4. Agents collaborate via AG2 GroupChat with automatic tool execution

## Key features

- **Zero setup**: Uses Milvus Lite (in-process, no Docker needed)
- **OpenAI embeddings**: `text-embedding-3-small` for text vectorization
- **Multi-agent RAG**: Researcher retrieves, Analyst synthesizes
- **Tool registration**: Milvus search exposed as AG2 tool via decorator pattern
- **Colab ready**: Can run directly in Google Colab

## Test plan

- [x] Tested locally with real OpenAI API calls — agents collaborate, retrieve from Milvus, and produce grounded answers
- [x] Black formatted
- [x] DCO signed