### PR TITLE
Add Google ADK and MemPalace Milvus notebooks

### DIFF
--- a/integration/basic_memory_with_milvus.md
+++ b/integration/basic_memory_with_milvus.md
@@ -1,0 +1,302 @@
+# Build Semantic Project Memory with Basic Memory and Milvus
+
+[Basic Memory](https://github.com/basicmachines-co/basic-memory) keeps project knowledge in ordinary Markdown files and makes it available through a CLI and MCP server. This gives a coding agent a durable place to remember decisions, runbooks, and lessons that should survive beyond one conversation.
+
+In this tutorial, we will build a small memory project for an application team. We will record notes about caching, authentication, deployments, and backups, then retrieve the right note with semantic and hybrid search.
+
+[Milvus](https://milvus.io/) will store the vectors and run similarity search. Basic Memory will continue to manage the Markdown notes, project metadata, full-text search, and vector manifest in PostgreSQL.
+
+```text
+Markdown notes
+      |
+      v
+Basic Memory CLI / MCP
+      |-- PostgreSQL: projects, metadata, full-text search, vector manifest
+      |-- OpenAI: embeddings
+      `-- Milvus: vector persistence and similarity search
+```
+
+This tutorial uses Milvus Lite, which runs locally at a path on your machine. The same Basic Memory configuration can later point to Milvus Standalone, Milvus Distributed, or Zilliz Cloud.
+
+## Prerequisites
+
+You need:
+
+- Python 3.12 or later
+- [`uv`](https://docs.astral.sh/uv/)
+- A PostgreSQL database and its `postgresql+asyncpg://...` connection URL
+- An OpenAI API key
+
+Milvus support has been merged into Basic Memory but is not yet available in its current PyPI release. Until the next release is published, install the tested upstream commit that includes the Milvus restart fix:
+
+```bash
+uv tool install --python 3.12 \
+  "basic-memory[milvus] @ git+https://github.com/basicmachines-co/basic-memory.git@eedce9bb92750282ceec73f420bb6ef05e954d4c"
+```
+
+After Basic Memory publishes a release containing the integration, the installation can be simplified to:
+
+```bash
+uv tool install --python 3.12 "basic-memory[milvus]"
+```
+
+## Configure Basic Memory
+
+Create a workspace for the tutorial. Keeping the Basic Memory configuration and Milvus Lite data here makes the example easy to inspect and remove later.
+
+```bash
+mkdir -p basic-memory-milvus-demo/notes
+cd basic-memory-milvus-demo
+
+export BASIC_MEMORY_CONFIG_DIR="$PWD/.basic-memory"
+```
+
+Configure PostgreSQL as the primary database, OpenAI as the embedding provider, and Milvus as the vector index:
+
+```bash
+export BASIC_MEMORY_DATABASE_BACKEND=postgres
+export BASIC_MEMORY_DATABASE_URL="postgresql+asyncpg://USER:PASSWORD@HOST:5432/DATABASE"
+
+export BASIC_MEMORY_SEMANTIC_SEARCH_ENABLED=true
+export BASIC_MEMORY_SEMANTIC_VECTOR_INDEX=milvus
+export BASIC_MEMORY_MILVUS_URI="$PWD/basic-memory-vectors.db"
+
+export BASIC_MEMORY_SEMANTIC_EMBEDDING_PROVIDER=openai
+export BASIC_MEMORY_SEMANTIC_EMBEDDING_MODEL=text-embedding-3-small
+export OPENAI_API_KEY="sk-***********"
+```
+
+Here, `BASIC_MEMORY_MILVUS_URI` is a local path, so PyMilvus starts Milvus Lite automatically. No separate Milvus server is required.
+
+Milvus is optional in Basic Memory as a whole, but it is the selected vector backend in this tutorial. The selection currently applies only when the primary database backend is PostgreSQL. SQLite-based Basic Memory projects use `sqlite-vec` instead.
+
+## Create a memory project
+
+A Basic Memory project maps a name to a directory of Markdown notes. Add the tutorial directory as a project and make it the default:
+
+```bash
+bm project add app-memory "$PWD/notes" --default
+```
+
+The application team now has a durable memory space. Let us fill it with a small, mixed catalog. Some notes will be relevant to our later questions, while others provide realistic distractors.
+
+## Record project memories
+
+Start with the application's caching decision:
+
+```bash
+bm tool write-note \
+  --title "Caching Strategy" \
+  --folder "engineering" \
+  --project app-memory <<'EOF'
+# Caching Strategy
+
+The application caches read-heavy product responses in Redis for five minutes. This avoids repeated database queries and makes repeated requests faster. Cache entries are invalidated immediately after a write.
+EOF
+```
+
+Record how authentication tokens are handled:
+
+```bash
+bm tool write-note \
+  --title "Authentication Tokens" \
+  --folder "engineering" \
+  --project app-memory <<'EOF'
+# Authentication Tokens
+
+JWT access tokens expire after fifteen minutes. Refresh tokens rotate on every use. After suspicious activity, revoke the entire token family and require the user to sign in again.
+EOF
+```
+
+Add two operational runbooks:
+
+```bash
+bm tool write-note \
+  --title "Deployment Reliability" \
+  --folder "operations" \
+  --project app-memory <<'EOF'
+# Deployment Reliability
+
+Production releases use a canary deployment. Readiness probes must pass before traffic shifts, and the rollout automatically stops when the error rate crosses the agreed threshold.
+EOF
+
+bm tool write-note \
+  --title "Database Backups" \
+  --folder "operations" \
+  --project app-memory <<'EOF'
+# Database Backups
+
+PostgreSQL uses daily snapshots and continuous write-ahead log archiving. The team runs a restore drill every month and records the recovery point and recovery time.
+EOF
+```
+
+Finally, add two unrelated product notes. These make the search exercise more representative than a catalog in which every document is relevant:
+
+```bash
+bm tool write-note \
+  --title "UI Accessibility" \
+  --folder "product" \
+  --project app-memory <<'EOF'
+# UI Accessibility
+
+The settings screen must support keyboard navigation, visible focus states, sufficient color contrast, and descriptive labels for screen readers.
+EOF
+
+bm tool write-note \
+  --title "Content Planning" \
+  --folder "product" \
+  --project app-memory <<'EOF'
+# Content Planning
+
+The content calendar tracks blog drafts, launch screenshots, reviewers, and publication dates for the next product release.
+EOF
+```
+
+Every note is still an ordinary Markdown file under `notes/`. Basic Memory adds the searchable structure without taking ownership away from the filesystem.
+
+## Build the search indexes
+
+Run a full reindex after adding or substantially changing a group of notes:
+
+```bash
+bm reindex --full --project app-memory
+```
+
+During this step, Basic Memory:
+
+1. Reads and chunks the Markdown notes.
+1. Builds the PostgreSQL full-text index.
+1. Sends the chunks to the configured OpenAI embedding model.
+1. Stores the resulting vectors in the project-specific Milvus collection.
+1. Marks successfully stored chunks as ready in its PostgreSQL vector manifest.
+
+Basic Memory uses a deterministic Milvus collection for each project. You do not need to create or name the collection yourself.
+
+## Retrieve a memory by meaning
+
+Suppose a new engineer remembers that the application has an optimization for repeated requests, but does not remember that the team called it a caching strategy.
+
+Use vector search to ask the question in natural language:
+
+```bash
+bm tool search-notes \
+  "How does the application make repeated requests faster?" \
+  --vector \
+  --project app-memory \
+  --page-size 3 \
+  --plain
+```
+
+`Caching Strategy` should be the leading result even though the query does not need to repeat the note title. Vector search embeds the question and asks Milvus for the nearest stored chunks.
+
+Exact scores and lower-ranked results can vary with the embedding model and the contents of the project.
+
+## Combine semantic and keyword signals
+
+Now imagine responding to a security incident. The query contains exact terms such as `JWT`, but we also want conceptually related language about token revocation and signing in again.
+
+Use hybrid search:
+
+```bash
+bm tool search-notes \
+  "JWT rotation after suspicious activity" \
+  --hybrid \
+  --project app-memory \
+  --page-size 3 \
+  --plain
+```
+
+`Authentication Tokens` should be the leading result. Basic Memory combines PostgreSQL full-text retrieval with Milvus vector retrieval, rewarding content that is strong in either path and especially content found by both.
+
+The three search modes have different strengths:
+
+| Mode      | Command flag | Best use                                                          |
+| --------- | ------------ | ----------------------------------------------------------------- |
+| Full text | No mode flag | Exact terms, phrases, and boolean keyword queries                 |
+| Vector    | `--vector`   | Paraphrases, concepts, and exploratory questions                  |
+| Hybrid    | `--hybrid`   | General-purpose retrieval using both keyword and semantic signals |
+
+## Use another Milvus deployment
+
+The application code and Basic Memory commands do not change when you outgrow Milvus Lite. Change the URI and, when required, provide a token.
+
+For a Milvus server:
+
+```bash
+export BASIC_MEMORY_MILVUS_URI="http://localhost:19530"
+export BASIC_MEMORY_MILVUS_TOKEN="root:Milvus"
+```
+
+For Zilliz Cloud:
+
+```bash
+export BASIC_MEMORY_MILVUS_URI="https://YOUR_CLUSTER_ENDPOINT"
+export BASIC_MEMORY_MILVUS_TOKEN="YOUR_API_KEY"
+```
+
+Create a fresh target collection or follow Basic Memory's vector-store migration procedure before switching an existing project between vector backends. Then rebuild the vectors:
+
+```bash
+bm reindex --full --project app-memory
+```
+
+## Use the same memory through MCP
+
+The CLI is useful for setup, maintenance, scripting, and understanding the data flow. In daily work, an MCP client can start the same Basic Memory service and call tools such as `write_note`, `search_notes`, and `build_context` directly.
+
+For example, a Codex MCP configuration can run the command installed by `uv tool`:
+
+```toml
+[mcp_servers.basic-memory]
+command = "basic-memory"
+args = ["mcp"]
+
+[mcp_servers.basic-memory.env]
+BASIC_MEMORY_CONFIG_DIR = "/absolute/path/to/basic-memory-milvus-demo/.basic-memory"
+BASIC_MEMORY_DATABASE_BACKEND = "postgres"
+BASIC_MEMORY_DATABASE_URL = "postgresql+asyncpg://USER:PASSWORD@HOST:5432/DATABASE"
+BASIC_MEMORY_SEMANTIC_SEARCH_ENABLED = "true"
+BASIC_MEMORY_SEMANTIC_VECTOR_INDEX = "milvus"
+BASIC_MEMORY_MILVUS_URI = "/absolute/path/to/basic-memory-milvus-demo/basic-memory-vectors.db"
+BASIC_MEMORY_SEMANTIC_EMBEDDING_PROVIDER = "openai"
+BASIC_MEMORY_SEMANTIC_EMBEDDING_MODEL = "text-embedding-3-small"
+OPENAI_API_KEY = "sk-***********"
+```
+
+Other MCP clients use the same executable and arguments in JSON form:
+
+```json
+{
+  "mcpServers": {
+    "basic-memory": {
+      "command": "basic-memory",
+      "args": ["mcp"],
+      "env": {
+        "BASIC_MEMORY_CONFIG_DIR": "/absolute/path/to/basic-memory-milvus-demo/.basic-memory",
+        "BASIC_MEMORY_DATABASE_BACKEND": "postgres",
+        "BASIC_MEMORY_DATABASE_URL": "postgresql+asyncpg://USER:PASSWORD@HOST:5432/DATABASE",
+        "BASIC_MEMORY_SEMANTIC_SEARCH_ENABLED": "true",
+        "BASIC_MEMORY_SEMANTIC_VECTOR_INDEX": "milvus",
+        "BASIC_MEMORY_MILVUS_URI": "/absolute/path/to/basic-memory-milvus-demo/basic-memory-vectors.db",
+        "BASIC_MEMORY_SEMANTIC_EMBEDDING_PROVIDER": "openai",
+        "BASIC_MEMORY_SEMANTIC_EMBEDDING_MODEL": "text-embedding-3-small",
+        "OPENAI_API_KEY": "sk-***********"
+      }
+    }
+  }
+}
+```
+
+Keep database passwords and API keys in your client's secret management or launch environment when possible. The important requirement is that the MCP process receives the same Basic Memory configuration used by the CLI.
+
+## What each storage layer owns
+
+At the end of the tutorial, the responsibilities are deliberately separated:
+
+- The project directory owns the original Markdown notes.
+- PostgreSQL owns Basic Memory's projects, entities, metadata, full-text index, and authoritative vector manifest.
+- OpenAI turns note chunks and search questions into embeddings.
+- Milvus owns vector persistence and nearest-neighbor retrieval.
+- Basic Memory coordinates the layers and exposes one CLI and MCP experience.
+
+Milvus therefore does not replace PostgreSQL in this integration. It replaces the PostgreSQL `pgvector` path for vector storage and similarity search, while the rest of Basic Memory's relational and full-text features remain in PostgreSQL.

--- a/integration/google_adk_with_milvus.ipynb
+++ b/integration/google_adk_with_milvus.ipynb
@@ -1,0 +1,809 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "27b4b74b",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/milvus-io/bootcamp/blob/master/integration/google_adk_with_milvus.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>   <a href=\"https://github.com/milvus-io/bootcamp/blob/master/integration/google_adk_with_milvus.ipynb\" target=\"_blank\">\n",
+    "    <img src=\"https://img.shields.io/badge/View%20on%20GitHub-555555?style=flat&logo=github&logoColor=white\" alt=\"GitHub Repository\"/>\n",
+    "</a>\n",
+    "\n",
+    "# Google ADK with Milvus\n",
+    "\n",
+    "[Google Agent Development Kit (ADK)](https://adk.dev/) helps developers build agents with tools, sessions, runners, and memory services. [Milvus](https://milvus.io/) is an open-source vector database built for embedding similarity search and AI memory workloads.\n",
+    "\n",
+    "In this tutorial, we will use [`adk-milvus`](https://github.com/zilliztech/adk-milvus) to connect ADK with Milvus in two common places: a retrieval toolset over a knowledge base, and a cross-session memory service for user-specific agent memory. The notebook uses Milvus Lite by default, so it can run locally or in Google Colab without a separate Milvus server.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "Install the ADK Milvus integration and Milvus dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a428ca93",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T10:14:36.258145Z",
+     "iopub.status.busy": "2026-07-17T10:14:36.257961Z",
+     "iopub.status.idle": "2026-07-17T10:14:37.589662Z",
+     "shell.execute_reply": "2026-07-17T10:14:37.586675Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "! pip install --upgrade adk-milvus google-genai pymilvus milvus-lite"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e08579ea",
+   "metadata": {},
+   "source": [
+    "> If you are using Google Colab, to enable dependencies just installed, you may need to **restart the runtime** (click on the \"Runtime\" menu at the top of the screen, and select \"Restart session\" from the dropdown menu).\n",
+    "\n",
+    "This notebook uses Gemini for both embeddings and the final agent turn. Prepare a `GEMINI_API_KEY` or `GOOGLE_API_KEY` environment variable before running it. The examples below use `gemini-embedding-001` to generate real embeddings and `gemini-2.5-flash` for the ADK agent.\n",
+    "\n",
+    "## Set up a local Milvus workspace\n",
+    "\n",
+    "Create a temporary workspace, define the Milvus Lite database files, and prepare a Gemini embedding function for the demo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8c2bb54f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T10:14:37.597503Z",
+     "iopub.status.busy": "2026-07-17T10:14:37.596967Z",
+     "iopub.status.idle": "2026-07-17T10:14:40.715270Z",
+     "shell.execute_reply": "2026-07-17T10:14:40.712863Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Workspace: /tmp/google_adk_milvus_demo__btzq981\n",
+      "Embedding model: gemini-embedding-001\n",
+      "Embedding dimension: 3072\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import tempfile\n",
+    "import warnings\n",
+    "from pathlib import Path\n",
+    "from typing import Sequence\n",
+    "\n",
+    "from adk_milvus import (\n",
+    "    MilvusMemoryService,\n",
+    "    MilvusMemoryServiceConfig,\n",
+    "    MilvusToolset,\n",
+    "    MilvusVectorStore,\n",
+    "    MilvusVectorStoreSettings,\n",
+    ")\n",
+    "from google.adk.agents import Agent\n",
+    "from google.adk.events.event import Event\n",
+    "from google.adk.runners import Runner\n",
+    "from google.adk.sessions import InMemorySessionService\n",
+    "from google.genai import Client, types\n",
+    "from pymilvus import MilvusClient\n",
+    "\n",
+    "work_dir = Path(tempfile.mkdtemp(prefix=\"google_adk_milvus_demo_\"))\n",
+    "rag_db_path = work_dir / \"adk_rag.db\"\n",
+    "memory_db_path = work_dir / \"adk_memory.db\"\n",
+    "\n",
+    "GOOGLE_EMBEDDING_MODEL = \"gemini-embedding-001\"\n",
+    "google_api_key = os.getenv(\"GEMINI_API_KEY\") or os.getenv(\"GOOGLE_API_KEY\")\n",
+    "if not google_api_key:\n",
+    "    raise RuntimeError(\n",
+    "        \"Set GEMINI_API_KEY or GOOGLE_API_KEY before running this notebook.\"\n",
+    "    )\n",
+    "\n",
+    "embedding_client = Client(api_key=google_api_key)\n",
+    "\n",
+    "\n",
+    "def google_embedding(texts: Sequence[str]) -> list[list[float]]:\n",
+    "    response = embedding_client.models.embed_content(\n",
+    "        model=GOOGLE_EMBEDDING_MODEL,\n",
+    "        contents=list(texts),\n",
+    "    )\n",
+    "    return [list(embedding.values) for embedding in response.embeddings]\n",
+    "\n",
+    "\n",
+    "EMBEDDING_DIMENSION = len(google_embedding([\"Milvus vector database\"])[0])\n",
+    "\n",
+    "\n",
+    "print(f\"Workspace: {work_dir}\")\n",
+    "print(f\"Embedding model: {GOOGLE_EMBEDDING_MODEL}\")\n",
+    "print(f\"Embedding dimension: {EMBEDDING_DIMENSION}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "623327e6",
+   "metadata": {},
+   "source": [
+    "> As for the argument of `MilvusClient` used by the integration:\n",
+    "> - Setting the `uri` as a local file, e.g.`./milvus.db`, is the most convenient method, as it automatically utilizes [Milvus Lite](https://milvus.io/docs/milvus_lite.md) to store all data in this file.\n",
+    "> - If you have large scale of data, you can set up a more performant Milvus server on [docker or kubernetes](https://milvus.io/docs/quickstart.md). In this setup, please use the server uri, e.g.`http://localhost:19530`, as your `uri`.\n",
+    "> - If you want to use [Zilliz Cloud](https://zilliz.com/cloud), the fully managed cloud service for Milvus, adjust the `uri` and `token`, which correspond to the [Public Endpoint and Api key](https://docs.zilliz.com/docs/on-zilliz-cloud-console#free-cluster-details) in Zilliz Cloud.\n",
+    "\n",
+    "## Build an ADK retrieval toolset with Milvus\n",
+    "\n",
+    "`MilvusVectorStore` stores embedded text in Milvus, while `MilvusToolset` exposes that store as an ADK retrieval tool named `milvus_similarity_search`. We will index a small knowledge base with both relevant documents and unrelated distractors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1d9bb9aa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T10:14:40.729313Z",
+     "iopub.status.busy": "2026-07-17T10:14:40.728503Z",
+     "iopub.status.idle": "2026-07-17T10:14:42.221669Z",
+     "shell.execute_reply": "2026-07-17T10:14:42.219316Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'status': 'SUCCESS', 'inserted_count': 8}\n",
+      "Indexed sources: adk-toolset, adk-memory, zilliz-cloud, milvus-lite, operations-runbook, team-recipe, travel-plan, payroll-note\n"
+     ]
+    }
+   ],
+   "source": [
+    "RAG_COLLECTION = \"google_adk_milvus_rag\"\n",
+    "\n",
+    "knowledge_docs = [\n",
+    "    {\n",
+    "        \"id\": \"adk-toolset-doc\",\n",
+    "        \"source\": \"adk-toolset\",\n",
+    "        \"topic\": \"retrieval\",\n",
+    "        \"content\": (\n",
+    "            \"MilvusToolset exposes milvus_similarity_search as an ADK retrieval \"\n",
+    "            \"tool so agents can search product docs, runbooks, and other RAG content.\"\n",
+    "        ),\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"adk-memory-doc\",\n",
+    "        \"source\": \"adk-memory\",\n",
+    "        \"topic\": \"memory\",\n",
+    "        \"content\": (\n",
+    "            \"MilvusMemoryService implements ADK BaseMemoryService and stores \"\n",
+    "            \"cross-session user memory with app_name and user_id scope.\"\n",
+    "        ),\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"zilliz-cloud-doc\",\n",
+    "        \"source\": \"zilliz-cloud\",\n",
+    "        \"topic\": \"production\",\n",
+    "        \"content\": (\n",
+    "            \"Zilliz Cloud provides managed Milvus for production vector search, \"\n",
+    "            \"with cloud operations, backup planning, and deployment controls.\"\n",
+    "        ),\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"milvus-lite-doc\",\n",
+    "        \"source\": \"milvus-lite\",\n",
+    "        \"topic\": \"local-development\",\n",
+    "        \"content\": (\n",
+    "            \"Milvus Lite stores vectors in a local database file and is useful \"\n",
+    "            \"for offline ADK prototypes before moving to a server or cloud deployment.\"\n",
+    "        ),\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"latency-runbook-doc\",\n",
+    "        \"source\": \"operations-runbook\",\n",
+    "        \"topic\": \"operations\",\n",
+    "        \"content\": (\n",
+    "            \"The production runbook tracks vector search latency, index readiness, \"\n",
+    "            \"and restore steps for Milvus-backed applications.\"\n",
+    "        ),\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"recipe-doc\",\n",
+    "        \"source\": \"team-recipe\",\n",
+    "        \"topic\": \"distractor\",\n",
+    "        \"content\": \"A pasta recipe uses tomato sauce, fresh basil, and slow cooking notes.\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"travel-doc\",\n",
+    "        \"source\": \"travel-plan\",\n",
+    "        \"topic\": \"distractor\",\n",
+    "        \"content\": \"The travel plan compares hotel options, train tickets, and city walks.\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"payroll-doc\",\n",
+    "        \"source\": \"payroll-note\",\n",
+    "        \"topic\": \"distractor\",\n",
+    "        \"content\": \"The payroll note explains invoice timing and monthly expense categories.\",\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "vector_store = MilvusVectorStore(\n",
+    "    embedding_function=google_embedding,\n",
+    "    settings=MilvusVectorStoreSettings(\n",
+    "        uri=str(rag_db_path),\n",
+    "        collection_name=RAG_COLLECTION,\n",
+    "        dimension=EMBEDDING_DIMENSION,\n",
+    "        search_top_k=4,\n",
+    "        consistency_level=\"Strong\",\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "insert_result = await vector_store.add_texts_async(\n",
+    "    [doc[\"content\"] for doc in knowledge_docs],\n",
+    "    metadatas=[\n",
+    "        {\"source\": doc[\"source\"], \"topic\": doc[\"topic\"]} for doc in knowledge_docs\n",
+    "    ],\n",
+    "    ids=[doc[\"id\"] for doc in knowledge_docs],\n",
+    ")\n",
+    "\n",
+    "print(insert_result)\n",
+    "print(\"Indexed sources:\", \", \".join(doc[\"source\"] for doc in knowledge_docs))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b11dc0e",
+   "metadata": {},
+   "source": [
+    "Now ask the ADK toolset for tools and run the Milvus retrieval tool directly. Running the tool directly verifies the Milvus-backed retrieval path before we involve the LLM; in a full ADK app, the agent can call the same tool during a model turn."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bb6681c8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T10:14:42.227632Z",
+     "iopub.status.busy": "2026-07-17T10:14:42.227181Z",
+     "iopub.status.idle": "2026-07-17T10:14:42.600296Z",
+     "shell.execute_reply": "2026-07-17T10:14:42.597958Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ADK tools: ['milvus_similarity_search']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#1 | source=adk-toolset | topic=retrieval\n",
+      "MilvusToolset exposes milvus_similarity_search as an ADK retrieval tool so agents can search product docs, runbooks, and other RAG content.\n",
+      "\n",
+      "#2 | source=milvus-lite | topic=local-development\n",
+      "Milvus Lite stores vectors in a local database file and is useful for offline ADK prototypes before moving to a server or cloud deployment.\n",
+      "\n",
+      "#3 | source=adk-memory | topic=memory\n",
+      "MilvusMemoryService implements ADK BaseMemoryService and stores cross-session user memory with app_name and user_id scope.\n",
+      "\n",
+      "#4 | source=operations-runbook | topic=operations\n",
+      "The production runbook tracks vector search latency, index readiness, and restore steps for Milvus-backed applications.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "toolset = MilvusToolset(vector_store=vector_store)\n",
+    "tools = await toolset.get_tools_with_prefix()\n",
+    "print(\"ADK tools:\", [tool.name for tool in tools])\n",
+    "\n",
+    "retrieval_result = await tools[0].run_async(\n",
+    "    args={\"query\": \"Which ADK tool should retrieve Milvus product docs for an agent?\"},\n",
+    "    tool_context=None,\n",
+    ")\n",
+    "\n",
+    "for rank, row in enumerate(retrieval_result[\"rows\"], start=1):\n",
+    "    metadata = row.get(\"metadata\") or {}\n",
+    "    print(f\"#{rank} | source={row['source']} | topic={metadata.get('topic')}\")\n",
+    "    print(row[\"content\"])\n",
+    "    print()\n",
+    "\n",
+    "assert retrieval_result[\"rows\"], \"The retrieval tool should return matching rows.\"\n",
+    "assert retrieval_result[\"rows\"][0][\"source\"] == \"adk-toolset\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45d511fd",
+   "metadata": {},
+   "source": [
+    "Because the store is backed by Milvus, you can also use metadata filters for narrower retrieval. The next query searches for production Milvus operations and restricts results to the Zilliz Cloud source."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b6375650",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T10:14:42.606356Z",
+     "iopub.status.busy": "2026-07-17T10:14:42.605895Z",
+     "iopub.status.idle": "2026-07-17T10:14:42.965643Z",
+     "shell.execute_reply": "2026-07-17T10:14:42.963057Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#1 | source=zilliz-cloud\n",
+      "Zilliz Cloud provides managed Milvus for production vector search, with cloud operations, backup planning, and deployment controls.\n"
+     ]
+    }
+   ],
+   "source": [
+    "filtered_result = await vector_store.similarity_search_async(\n",
+    "    \"managed cloud production Milvus operations\",\n",
+    "    top_k=3,\n",
+    "    filter_expr='source == \"zilliz-cloud\"',\n",
+    ")\n",
+    "\n",
+    "for rank, row in enumerate(filtered_result[\"rows\"], start=1):\n",
+    "    print(f\"#{rank} | source={row['source']}\")\n",
+    "    print(row[\"content\"])\n",
+    "\n",
+    "assert filtered_result[\"rows\"]\n",
+    "assert all(row[\"source\"] == \"zilliz-cloud\" for row in filtered_result[\"rows\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0fd5f08",
+   "metadata": {},
+   "source": [
+    "We can inspect the same Milvus Lite database with `MilvusClient`. This confirms that the ADK integration wrote ordinary Milvus rows containing ids, content, source metadata, and embeddings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "83580612",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T10:14:42.971991Z",
+     "iopub.status.busy": "2026-07-17T10:14:42.971545Z",
+     "iopub.status.idle": "2026-07-17T10:14:43.034630Z",
+     "shell.execute_reply": "2026-07-17T10:14:43.032021Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collection stats: {'row_count': 8}\n",
+      "Sample rows:\n",
+      "- adk-toolset-doc | adk-toolset | MilvusToolset exposes milvus_similarity_search as an ADK retrieval tool so agents can sear\n",
+      "- recipe-doc | team-recipe | A pasta recipe uses tomato sauce, fresh basil, and slow cooking notes.\n"
+     ]
+    }
+   ],
+   "source": [
+    "inspection_client = MilvusClient(uri=str(rag_db_path))\n",
+    "stats = inspection_client.get_collection_stats(RAG_COLLECTION)\n",
+    "sample_rows = inspection_client.query(\n",
+    "    collection_name=RAG_COLLECTION,\n",
+    "    filter='source in [\"adk-toolset\", \"team-recipe\"]',\n",
+    "    output_fields=[\"id\", \"source\", \"content\"],\n",
+    "    limit=4,\n",
+    ")\n",
+    "inspection_client.close()\n",
+    "\n",
+    "print(\"Collection stats:\", stats)\n",
+    "print(\"Sample rows:\")\n",
+    "for row in sample_rows:\n",
+    "    print(f\"- {row['id']} | {row['source']} | {row['content'][:90]}\")\n",
+    "\n",
+    "assert stats[\"row_count\"] == len(knowledge_docs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eaa274b2",
+   "metadata": {},
+   "source": [
+    "## Store ADK memory in Milvus\n",
+    "\n",
+    "Retrieval tools are useful for shared knowledge bases. Agent memory is different: it should be scoped to a specific app and user, and it should survive across sessions. `MilvusMemoryService` implements ADK's memory service interface while using Milvus as the vector store underneath."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c4c95326",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T10:14:43.040350Z",
+     "iopub.status.busy": "2026-07-17T10:14:43.039863Z",
+     "iopub.status.idle": "2026-07-17T10:14:44.408320Z",
+     "shell.execute_reply": "2026-07-17T10:14:44.406135Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stored memory events: 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "MEMORY_COLLECTION = \"google_adk_milvus_memory\"\n",
+    "APP_NAME = \"google-adk-milvus-demo\"\n",
+    "\n",
+    "memory_service = MilvusMemoryService(\n",
+    "    embedding_function=google_embedding,\n",
+    "    config=MilvusMemoryServiceConfig(\n",
+    "        uri=str(memory_db_path),\n",
+    "        collection_name=MEMORY_COLLECTION,\n",
+    "        dimension=EMBEDDING_DIMENSION,\n",
+    "        search_top_k=2,\n",
+    "        consistency_level=\"Strong\",\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "user_1_events = [\n",
+    "    Event(\n",
+    "        id=\"user-1-event-1\",\n",
+    "        invocation_id=\"inv-user-1-1\",\n",
+    "        author=\"user\",\n",
+    "        timestamp=10001,\n",
+    "        content=types.Content(\n",
+    "            parts=[\n",
+    "                types.Part(\n",
+    "                    text=(\n",
+    "                        \"Remember that I prefer Milvus Lite for local ADK memory \"\n",
+    "                        \"prototypes before using a shared server.\"\n",
+    "                    )\n",
+    "                )\n",
+    "            ]\n",
+    "        ),\n",
+    "    ),\n",
+    "    Event(\n",
+    "        id=\"user-1-event-2\",\n",
+    "        invocation_id=\"inv-user-1-2\",\n",
+    "        author=\"user\",\n",
+    "        timestamp=10002,\n",
+    "        content=types.Content(\n",
+    "            parts=[\n",
+    "                types.Part(\n",
+    "                    text=(\n",
+    "                        \"For production, remember that our ADK agent should use \"\n",
+    "                        \"Zilliz Cloud for managed Milvus vector memory.\"\n",
+    "                    )\n",
+    "                )\n",
+    "            ]\n",
+    "        ),\n",
+    "    ),\n",
+    "    Event(\n",
+    "        id=\"user-1-event-3\",\n",
+    "        invocation_id=\"inv-user-1-3\",\n",
+    "        author=\"user\",\n",
+    "        timestamp=10003,\n",
+    "        content=types.Content(\n",
+    "            parts=[types.Part(text=\"I also like cooking noodles on Friday evenings.\")]\n",
+    "        ),\n",
+    "    ),\n",
+    "]\n",
+    "\n",
+    "user_2_events = [\n",
+    "    Event(\n",
+    "        id=\"user-2-event-1\",\n",
+    "        invocation_id=\"inv-user-2-1\",\n",
+    "        author=\"user\",\n",
+    "        timestamp=20001,\n",
+    "        content=types.Content(\n",
+    "            parts=[\n",
+    "                types.Part(\n",
+    "                    text=(\n",
+    "                        \"User two keeps travel planning notes and hotel preferences \"\n",
+    "                        \"in a separate ADK memory scope.\"\n",
+    "                    )\n",
+    "                )\n",
+    "            ]\n",
+    "        ),\n",
+    "    )\n",
+    "]\n",
+    "\n",
+    "await memory_service.add_events_to_memory(\n",
+    "    app_name=APP_NAME,\n",
+    "    user_id=\"user-1\",\n",
+    "    session_id=\"session-local-and-cloud\",\n",
+    "    events=user_1_events,\n",
+    ")\n",
+    "await memory_service.add_events_to_memory(\n",
+    "    app_name=APP_NAME,\n",
+    "    user_id=\"user-2\",\n",
+    "    session_id=\"session-other-user\",\n",
+    "    events=user_2_events,\n",
+    ")\n",
+    "\n",
+    "print(\"Stored memory events:\", len(user_1_events) + len(user_2_events))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "790eb36f",
+   "metadata": {},
+   "source": [
+    "Search memory for one user. The service automatically filters by `app_name` and `user_id`, so another user's events do not leak into the result set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ba23f34d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T10:14:44.414574Z",
+     "iopub.status.busy": "2026-07-17T10:14:44.414148Z",
+     "iopub.status.idle": "2026-07-17T10:14:45.837842Z",
+     "shell.execute_reply": "2026-07-17T10:14:45.835067Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "User 1 memory search:\n",
+      "#1 | author=user | timestamp=1970-01-01T02:46:42\n",
+      "For production, remember that our ADK agent should use Zilliz Cloud for managed Milvus vector memory.\n",
+      "\n",
+      "#2 | author=user | timestamp=1970-01-01T02:46:41\n",
+      "Remember that I prefer Milvus Lite for local ADK memory prototypes before using a shared server.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "User 2 scoped result:\n",
+      "User two keeps travel planning notes and hotel preferences in a separate ADK memory scope.\n",
+      "User 3 result count: 0\n",
+      "Different app result count: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "memory_result = await memory_service.search_memory(\n",
+    "    app_name=APP_NAME,\n",
+    "    user_id=\"user-1\",\n",
+    "    query=\"production Milvus memory preference for my ADK agent\",\n",
+    ")\n",
+    "\n",
+    "print(\"User 1 memory search:\")\n",
+    "for rank, memory in enumerate(memory_result.memories, start=1):\n",
+    "    print(f\"#{rank} | author={memory.author} | timestamp={memory.timestamp}\")\n",
+    "    print(memory.content.parts[0].text)\n",
+    "    print()\n",
+    "\n",
+    "user_2_result = await memory_service.search_memory(\n",
+    "    app_name=APP_NAME,\n",
+    "    user_id=\"user-2\",\n",
+    "    query=\"travel planning memory\",\n",
+    ")\n",
+    "empty_user_result = await memory_service.search_memory(\n",
+    "    app_name=APP_NAME,\n",
+    "    user_id=\"user-3\",\n",
+    "    query=\"production Milvus memory preference for my ADK agent\",\n",
+    ")\n",
+    "wrong_app_result = await memory_service.search_memory(\n",
+    "    app_name=\"different-adk-app\",\n",
+    "    user_id=\"user-1\",\n",
+    "    query=\"production Milvus memory preference for my ADK agent\",\n",
+    ")\n",
+    "\n",
+    "print(\"User 2 scoped result:\")\n",
+    "for memory in user_2_result.memories:\n",
+    "    print(memory.content.parts[0].text)\n",
+    "print(\"User 3 result count:\", len(empty_user_result.memories))\n",
+    "print(\"Different app result count:\", len(wrong_app_result.memories))\n",
+    "\n",
+    "user_1_texts = [memory.content.parts[0].text for memory in memory_result.memories]\n",
+    "assert any(\"Zilliz Cloud\" in text for text in user_1_texts)\n",
+    "assert all(\n",
+    "    \"Zilliz Cloud\" not in memory.content.parts[0].text\n",
+    "    for memory in user_2_result.memories\n",
+    ")\n",
+    "assert empty_user_result.memories == []\n",
+    "assert wrong_app_result.memories == []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02d693c3",
+   "metadata": {},
+   "source": [
+    "## Attach Milvus tools to an ADK agent\n",
+    "\n",
+    "The previous cells executed the retrieval tool directly, which verifies the Milvus-backed tool before involving the model. The same tool list can also be attached to an ADK `Agent`. The next cell runs a live Gemini turn through ADK Runner and shows that the model calls `milvus_similarity_search` before answering."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c8769259",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T10:14:45.844794Z",
+     "iopub.status.busy": "2026-07-17T10:14:45.844298Z",
+     "iopub.status.idle": "2026-07-17T10:14:49.032966Z",
+     "shell.execute_reply": "2026-07-17T10:14:49.030916Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Agent: milvus_research_agent\n",
+      "Attached tools: ['milvus_similarity_search']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LLM tool calls: ['milvus_similarity_search']\n",
+      "LLM tool responses: ['milvus_similarity_search']\n",
+      "Final answer:\n",
+      "The ADK Milvus integration provides agents with the ability to search product documentation, runbooks, and other RAG content through the `milvus_similarity_search` tool, as stated in the \"adk-toolset\" source. It also offers a `MilvusMemoryService` for storing cross-session user memory, as mentioned in the \"adk-memory\" source. For development, \"milvus-lite\" allows for offline prototyping by storing vectors in a local database file, and for production, \"zilliz-cloud\" provides managed Milvus for vector search with cloud operations and deployment controls.\n"
+     ]
+    }
+   ],
+   "source": [
+    "agent = Agent(\n",
+    "    name=\"milvus_research_agent\",\n",
+    "    model=\"gemini-2.5-flash\",\n",
+    "    instruction=(\n",
+    "        \"You are a concise assistant. Use milvus_similarity_search before \"\n",
+    "        \"answering questions about ADK, Milvus deployment, or vector memory. \"\n",
+    "        \"Mention source names from retrieved rows when useful.\"\n",
+    "    ),\n",
+    "    tools=tools,\n",
+    ")\n",
+    "\n",
+    "print(\"Agent:\", agent.name)\n",
+    "print(\"Attached tools:\", [tool.name for tool in agent.tools])\n",
+    "\n",
+    "model_key_available = bool(os.getenv(\"GEMINI_API_KEY\") or os.getenv(\"GOOGLE_API_KEY\"))\n",
+    "if not model_key_available:\n",
+    "    print(\"Set GEMINI_API_KEY or GOOGLE_API_KEY to run the live LLM turn.\")\n",
+    "else:\n",
+    "    session_service = InMemorySessionService()\n",
+    "    llm_user_id = \"user-llm\"\n",
+    "    llm_session_id = \"session-llm\"\n",
+    "    await session_service.create_session(\n",
+    "        app_name=APP_NAME,\n",
+    "        user_id=llm_user_id,\n",
+    "        session_id=llm_session_id,\n",
+    "    )\n",
+    "    runner = Runner(\n",
+    "        app_name=APP_NAME,\n",
+    "        agent=agent,\n",
+    "        session_service=session_service,\n",
+    "    )\n",
+    "    prompt = (\n",
+    "        \"Use the Milvus retrieval tool to answer: \"\n",
+    "        \"What does the ADK Milvus integration provide for agents?\"\n",
+    "    )\n",
+    "\n",
+    "    tool_calls = []\n",
+    "    tool_responses = []\n",
+    "    final_answer = \"\"\n",
+    "    with warnings.catch_warnings():\n",
+    "        warnings.filterwarnings(\n",
+    "            \"ignore\",\n",
+    "            message=\".*JSON_SCHEMA_FOR_FUNC_DECL.*\",\n",
+    "            category=UserWarning,\n",
+    "        )\n",
+    "        async for event in runner.run_async(\n",
+    "            user_id=llm_user_id,\n",
+    "            session_id=llm_session_id,\n",
+    "            new_message=types.Content(\n",
+    "                role=\"user\",\n",
+    "                parts=[types.Part(text=prompt)],\n",
+    "            ),\n",
+    "        ):\n",
+    "            tool_calls.extend(call.name for call in event.get_function_calls())\n",
+    "            tool_responses.extend(\n",
+    "                response.name for response in event.get_function_responses()\n",
+    "            )\n",
+    "            if event.is_final_response() and event.content and event.content.parts:\n",
+    "                final_answer = \"\".join(part.text or \"\" for part in event.content.parts)\n",
+    "\n",
+    "    print(\"LLM tool calls:\", tool_calls)\n",
+    "    print(\"LLM tool responses:\", tool_responses)\n",
+    "    print(\"Final answer:\")\n",
+    "    print(final_answer)\n",
+    "\n",
+    "    assert \"milvus_similarity_search\" in tool_calls\n",
+    "    assert final_answer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "494b21d1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T10:14:49.039775Z",
+     "iopub.status.busy": "2026-07-17T10:14:49.039466Z",
+     "iopub.status.idle": "2026-07-17T10:14:49.048663Z",
+     "shell.execute_reply": "2026-07-17T10:14:49.046876Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Milvus clients closed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "await toolset.close()\n",
+    "await memory_service.close()\n",
+    "print(\"Milvus clients closed.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac45aafe",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "This notebook showed how Milvus can sit behind two important ADK surfaces: retrieval tools for shared knowledge and memory services for user-scoped, cross-session context. It also ran a live ADK Runner turn where Gemini called the Milvus retrieval tool before answering. With Milvus Lite, the same integration is easy to prototype in a notebook; with Milvus server or Zilliz Cloud, the same configuration shape can support larger teams and production agent workloads.\n",
+    "\n",
+    "The key idea is that ADK keeps the agent interface clean while Milvus handles durable vector search, metadata filtering, and scalable memory storage underneath."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/integration/mempalace_with_milvus.ipynb
+++ b/integration/mempalace_with_milvus.ipynb
@@ -1,0 +1,617 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fdf9a28f-c72c-4680-b348-2ee33ed1127a",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/milvus-io/bootcamp/blob/master/integration/mempalace_with_milvus.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>   <a href=\"https://github.com/milvus-io/bootcamp/blob/master/integration/mempalace_with_milvus.ipynb\" target=\"_blank\">\n",
+    "    <img src=\"https://img.shields.io/badge/View%20on%20GitHub-555555?style=flat&logo=github&logoColor=white\" alt=\"GitHub Repository\"/>\n",
+    "</a>\n",
+    "\n",
+    "# MemPalace with Milvus\n",
+    "\n",
+    "[MemPalace](https://github.com/MemPalace/mempalace) is a memory layer for coding agents and long-running development workflows. It can mine and search project memories, conversation notes, and other \"drawers\" that help an agent keep useful context across sessions.\n",
+    "\n",
+    "In this tutorial, we will configure MemPalace to use [Milvus](https://milvus.io/) as its storage backend. The notebook uses Milvus Lite by default, so it can run locally or in Google Colab without a separate Milvus server. The same MemPalace configuration can also point to Milvus server or Zilliz Cloud for shared or production deployments.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "Install MemPalace with its optional Milvus dependencies from PyPI.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4e100df7-4388-47be-8f57-031063a4b240",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T08:43:02.669594Z",
+     "iopub.status.busy": "2026-07-23T08:43:02.669186Z",
+     "iopub.status.idle": "2026-07-23T08:43:04.005846Z",
+     "shell.execute_reply": "2026-07-23T08:43:04.003242Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "! pip install --upgrade \"mempalace[milvus]==3.6.0\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaf1bae6-5026-4844-9a67-483fb8eaf64e",
+   "metadata": {},
+   "source": [
+    "\n",
+    "> If you are using Google Colab, to enable dependencies just installed, you may need to **restart the runtime** (click on the \"Runtime\" menu at the top of the screen, and select \"Restart session\" from the dropdown menu).\n",
+    "\n",
+    "This tutorial uses MemPalace's local embedding model, so you do not need an external model API key. The first run may download a small ONNX embedding model.\n",
+    "\n",
+    "## Configure MemPalace to use Milvus\n",
+    "\n",
+    "MemPalace can work with a real project directory through its CLI, but a notebook is easier to run when it creates a temporary palace directory and inserts a small set of example memories. We set the backend to `milvus`, force CPU embeddings, and keep the demo inside a temporary folder.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8b3840b2-b54b-48ae-909a-af5996240cd6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T08:43:04.011377Z",
+     "iopub.status.busy": "2026-07-23T08:43:04.010943Z",
+     "iopub.status.idle": "2026-07-23T08:43:04.025606Z",
+     "shell.execute_reply": "2026-07-23T08:43:04.023885Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Palace directory: /tmp/mempalace_milvus_demo_k5scv8e9/palace\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "os.environ[\"MEMPALACE_BACKEND\"] = \"milvus\"\n",
+    "os.environ[\"MEMPALACE_EMBEDDING_MODEL\"] = \"minilm\"\n",
+    "os.environ[\"MEMPALACE_EMBEDDING_DEVICE\"] = \"cpu\"\n",
+    "os.environ[\"MEMPALACE_EMBEDDING_THREADS\"] = \"2\"\n",
+    "\n",
+    "work_dir = Path(tempfile.mkdtemp(prefix=\"mempalace_milvus_demo_\"))\n",
+    "palace_dir = work_dir / \"palace\"\n",
+    "palace_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "print(f\"Palace directory: {palace_dir}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6b6e7b3-edf1-4e0b-878a-facb34e9126e",
+   "metadata": {},
+   "source": [
+    "\n",
+    "When no remote Milvus URI is configured, the MemPalace Milvus backend creates a local Milvus Lite database at `<palace>/milvus.db`.\n",
+    "\n",
+    "> As for the argument of `MilvusClient` used by the backend:\n",
+    "> - Setting the `uri` as a local file, e.g. `./milvus.db`, is the most convenient method, as it automatically utilizes [Milvus Lite](https://milvus.io/docs/milvus_lite.md) to store all data in this file.\n",
+    "> - If you have large scale of data, you can set up a more performant Milvus server on [Docker or Kubernetes](https://milvus.io/docs/quickstart.md). In this setup, please use the server uri, e.g. `http://localhost:19530`, as your `uri`.\n",
+    "> - If you want to use [Zilliz Cloud](https://zilliz.com/cloud), the fully managed cloud service for Milvus, adjust the `uri` and `token`, which correspond to the [Public Endpoint and API key](https://docs.zilliz.com/docs/on-zilliz-cloud-console#free-cluster-details) in Zilliz Cloud.\n",
+    "\n",
+    "## Create a MemPalace collection\n",
+    "\n",
+    "MemPalace exposes `get_collection` as the main Python API for opening a memory drawer collection. Passing `backend=\"milvus\"` makes the collection use Milvus while still letting us call MemPalace methods such as `upsert`, `query`, and `lexical_search`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "eb3db855-43bd-4497-9219-37c696ca018c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T08:43:04.030614Z",
+     "iopub.status.busy": "2026-07-23T08:43:04.030064Z",
+     "iopub.status.idle": "2026-07-23T08:43:06.686330Z",
+     "shell.execute_reply": "2026-07-23T08:43:06.685096Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EmbeddingCollection\n"
+     ]
+    }
+   ],
+   "source": [
+    "from mempalace.palace import get_collection\n",
+    "\n",
+    "collection_name = \"mempalace_drawers\"\n",
+    "collection = get_collection(\n",
+    "    str(palace_dir),\n",
+    "    collection_name,\n",
+    "    create=True,\n",
+    "    backend=\"milvus\",\n",
+    ")\n",
+    "\n",
+    "print(type(collection).__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f01eb1f4-e6c2-45ba-9470-f1c4aab0b46e",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Add example project memories\n",
+    "\n",
+    "MemPalace organizes memory as `wings`, `rooms`, and `drawers`: a wing usually represents a project or person, a room represents a topic area, and a drawer stores the original memory text. Higher-level MemPalace flows such as `mempalace mine` can create these drawers from a project directory or conversation export. In this notebook, we write a few drawers directly so the Milvus integration is easy to see.\n",
+    "\n",
+    "The records below mimic a team using MemPalace as long-term project memory for a coding agent. The dataset intentionally mixes deployment, architecture, evaluation, retrieval, UI, and content-planning notes so the search examples have both relevant memories and unrelated distractors. MemPalace computes embeddings locally and stores the text, metadata, dense vectors, and BM25 lexical index in Milvus.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7f846767-b4ca-49b0-9ade-70cf30c65dd2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T08:43:06.689138Z",
+     "iopub.status.busy": "2026-07-23T08:43:06.688687Z",
+     "iopub.status.idle": "2026-07-23T08:43:08.745966Z",
+     "shell.execute_reply": "2026-07-23T08:43:08.743690Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inserted 8 memories\n",
+      "\n",
+      "Memory catalog:\n",
+      "- mem-001 room=architecture source=architecture-notes.md\n",
+      "- mem-002 room=deployment   source=local-dev-runbook.md\n",
+      "- mem-003 room=deployment   source=cloud-deployment.md\n",
+      "- mem-004 room=architecture source=storage-contract.md\n",
+      "- mem-005 room=evaluation   source=evaluation-checklist.md\n",
+      "- mem-006 room=retrieval    source=retrieval-playbook.md\n",
+      "- mem-007 room=ui           source=ui-style-guide.md\n",
+      "- mem-008 room=content      source=content-calendar.md\n"
+     ]
+    }
+   ],
+   "source": [
+    "memories = [\n",
+    "    {\n",
+    "        \"id\": \"mem-001\",\n",
+    "        \"text\": (\n",
+    "            \"The team uses MemPalace as a long-term memory layer for coding agents, \"\n",
+    "            \"with Milvus storing searchable drawers for architecture decisions and runbooks.\"\n",
+    "        ),\n",
+    "        \"metadata\": {\n",
+    "            \"wing\": \"milvus_memory_assistant\",\n",
+    "            \"room\": \"architecture\",\n",
+    "            \"source_file\": \"architecture-notes.md\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"mem-002\",\n",
+    "        \"text\": (\n",
+    "            \"Local development uses Milvus Lite so engineers can run the memory stack \"\n",
+    "            \"without a separate vector database service.\"\n",
+    "        ),\n",
+    "        \"metadata\": {\n",
+    "            \"wing\": \"milvus_memory_assistant\",\n",
+    "            \"room\": \"deployment\",\n",
+    "            \"source_file\": \"local-dev-runbook.md\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"mem-003\",\n",
+    "        \"text\": (\n",
+    "            \"For shared environments, the same MemPalace backend can point to Milvus \"\n",
+    "            \"server or Zilliz Cloud by setting MEMPALACE_MILVUS_URI and MEMPALACE_MILVUS_TOKEN.\"\n",
+    "        ),\n",
+    "        \"metadata\": {\n",
+    "            \"wing\": \"milvus_memory_assistant\",\n",
+    "            \"room\": \"deployment\",\n",
+    "            \"source_file\": \"cloud-deployment.md\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"mem-004\",\n",
+    "        \"text\": (\n",
+    "            \"The backend keeps verbatim memory text and metadata, while Milvus stores \"\n",
+    "            \"vectors and supports semantic search over drawers.\"\n",
+    "        ),\n",
+    "        \"metadata\": {\n",
+    "            \"wing\": \"milvus_memory_assistant\",\n",
+    "            \"room\": \"architecture\",\n",
+    "            \"source_file\": \"storage-contract.md\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"mem-005\",\n",
+    "        \"text\": (\n",
+    "            \"The evaluation checklist asks the agent to verify semantic search, \"\n",
+    "            \"metadata filters, and lexical search before publishing an integration guide.\"\n",
+    "        ),\n",
+    "        \"metadata\": {\n",
+    "            \"wing\": \"milvus_memory_assistant\",\n",
+    "            \"room\": \"evaluation\",\n",
+    "            \"source_file\": \"evaluation-checklist.md\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"mem-006\",\n",
+    "        \"text\": (\n",
+    "            \"When a query includes exact terms such as Zilliz Cloud token, the agent \"\n",
+    "            \"should use lexical search as a complement to vector similarity.\"\n",
+    "        ),\n",
+    "        \"metadata\": {\n",
+    "            \"wing\": \"milvus_memory_assistant\",\n",
+    "            \"room\": \"retrieval\",\n",
+    "            \"source_file\": \"retrieval-playbook.md\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"mem-007\",\n",
+    "        \"text\": (\n",
+    "            \"The dashboard UI should keep operational controls compact and avoid \"\n",
+    "            \"large hero sections in repeated engineering workflows.\"\n",
+    "        ),\n",
+    "        \"metadata\": {\n",
+    "            \"wing\": \"milvus_memory_assistant\",\n",
+    "            \"room\": \"ui\",\n",
+    "            \"source_file\": \"ui-style-guide.md\",\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"id\": \"mem-008\",\n",
+    "        \"text\": (\n",
+    "            \"The community content calendar tracks blog drafts, screenshots, and \"\n",
+    "            \"review dates for launch posts.\"\n",
+    "        ),\n",
+    "        \"metadata\": {\n",
+    "            \"wing\": \"milvus_memory_assistant\",\n",
+    "            \"room\": \"content\",\n",
+    "            \"source_file\": \"content-calendar.md\",\n",
+    "        },\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "collection.upsert(\n",
+    "    ids=[memory[\"id\"] for memory in memories],\n",
+    "    documents=[memory[\"text\"] for memory in memories],\n",
+    "    metadatas=[memory[\"metadata\"] for memory in memories],\n",
+    ")\n",
+    "\n",
+    "print(f\"Inserted {collection.count()} memories\")\n",
+    "print()\n",
+    "print(\"Memory catalog:\")\n",
+    "for memory in memories:\n",
+    "    metadata = memory[\"metadata\"]\n",
+    "    print(\n",
+    "        f\"- {memory['id']} room={metadata['room']:<12} \"\n",
+    "        f\"source={metadata['source_file']}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "783dde56-f4ff-4986-bfe8-d5284510c184",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Semantic search\n",
+    "\n",
+    "Use `query_texts` to search memories by meaning. The query below asks about running the memory stack locally without a database server. In the mixed memory catalog above, the most relevant results should come from the local deployment and Milvus backend notes, not from the UI or content-planning distractors.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3476094d-4aef-49bb-afeb-4b1df0e881c5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T08:43:08.751172Z",
+     "iopub.status.busy": "2026-07-23T08:43:08.750780Z",
+     "iopub.status.idle": "2026-07-23T08:43:08.858600Z",
+     "shell.execute_reply": "2026-07-23T08:43:08.857285Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1. mem-002 room=deployment source=local-dev-runbook.md\n",
+      "   Local development uses Milvus Lite so engineers can run the memory stack without a separate vector database service.\n",
+      "2. mem-001 room=architecture source=architecture-notes.md\n",
+      "   The team uses MemPalace as a long-term memory layer for coding agents, with Milvus storing searchable drawers for architecture decisions and runbooks.\n",
+      "3. mem-003 room=deployment source=cloud-deployment.md\n",
+      "   For shared environments, the same MemPalace backend can point to Milvus server or Zilliz Cloud by setting MEMPALACE_MILVUS_URI and MEMPALACE_MILVUS_TOKEN.\n"
+     ]
+    }
+   ],
+   "source": [
+    "semantic_results = collection.query(\n",
+    "    query_texts=[\"How can I run MemPalace memory locally without a database server?\"],\n",
+    "    n_results=3,\n",
+    "    include=[\"documents\", \"metadatas\"],\n",
+    ")\n",
+    "\n",
+    "for rank, (item_id, document, metadata) in enumerate(\n",
+    "    zip(\n",
+    "        semantic_results.ids[0],\n",
+    "        semantic_results.documents[0],\n",
+    "        semantic_results.metadatas[0],\n",
+    "    ),\n",
+    "    start=1,\n",
+    "):\n",
+    "    print(\n",
+    "        f\"{rank}. {item_id} room={metadata.get('room')} \"\n",
+    "        f\"source={metadata.get('source_file')}\"\n",
+    "    )\n",
+    "    print(f\"   {document}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0242e20b-0110-499d-922f-ce2f67a15ccf",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Search within a metadata scope\n",
+    "\n",
+    "Metadata filters are useful when a project has many memory rooms. This query searches for deployment guidance, but the `where={\"room\": \"deployment\"}` filter limits the search to deployment drawers even though the collection also contains architecture, evaluation, retrieval, UI, and content notes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "792764b5-a21c-4de4-a888-c8160172f290",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T08:43:08.862591Z",
+     "iopub.status.busy": "2026-07-23T08:43:08.862328Z",
+     "iopub.status.idle": "2026-07-23T08:43:08.951232Z",
+     "shell.execute_reply": "2026-07-23T08:43:08.950017Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1. mem-002 room=deployment source=local-dev-runbook.md\n",
+      "   Local development uses Milvus Lite so engineers can run the memory stack without a separate vector database service.\n",
+      "2. mem-003 room=deployment source=cloud-deployment.md\n",
+      "   For shared environments, the same MemPalace backend can point to Milvus server or Zilliz Cloud by setting MEMPALACE_MILVUS_URI and MEMPALACE_MILVUS_TOKEN.\n"
+     ]
+    }
+   ],
+   "source": [
+    "filtered_results = collection.query(\n",
+    "    query_texts=[\"How do we deploy this memory backend?\"],\n",
+    "    n_results=3,\n",
+    "    where={\"room\": \"deployment\"},\n",
+    "    include=[\"documents\", \"metadatas\"],\n",
+    ")\n",
+    "\n",
+    "for rank, (item_id, document, metadata) in enumerate(\n",
+    "    zip(\n",
+    "        filtered_results.ids[0],\n",
+    "        filtered_results.documents[0],\n",
+    "        filtered_results.metadatas[0],\n",
+    "    ),\n",
+    "    start=1,\n",
+    "):\n",
+    "    print(\n",
+    "        f\"{rank}. {item_id} room={metadata.get('room')} \"\n",
+    "        f\"source={metadata.get('source_file')}\"\n",
+    "    )\n",
+    "    print(f\"   {document}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcdff61d-a141-4f12-857e-074609eba288",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Lexical search\n",
+    "\n",
+    "The Milvus backend also creates a BM25 sparse index over the memory text. `lexical_search` is useful when you need exact terms such as environment variable names, product names, or file names. Here, the query contains `Zilliz Cloud token`, so the lexical results favor drawers that mention those exact words.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2d122809-cb31-424b-a658-32dd119ae7e8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T08:43:08.954849Z",
+     "iopub.status.busy": "2026-07-23T08:43:08.954695Z",
+     "iopub.status.idle": "2026-07-23T08:43:08.969956Z",
+     "shell.execute_reply": "2026-07-23T08:43:08.969009Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1. mem-006 room=retrieval source=retrieval-playbook.md\n",
+      "   When a query includes exact terms such as Zilliz Cloud token, the agent should use lexical search as a complement to vector similarity.\n",
+      "2. mem-003 room=deployment source=cloud-deployment.md\n",
+      "   For shared environments, the same MemPalace backend can point to Milvus server or Zilliz Cloud by setting MEMPALACE_MILVUS_URI and MEMPALACE_MILVUS_TOKEN.\n"
+     ]
+    }
+   ],
+   "source": [
+    "lexical_hits = collection.lexical_search(query=\"Zilliz Cloud token\", n_results=3).hits\n",
+    "\n",
+    "for rank, hit in enumerate(lexical_hits, start=1):\n",
+    "    print(\n",
+    "        f\"{rank}. {hit.id} room={hit.metadata.get('room')} \"\n",
+    "        f\"source={hit.metadata.get('source_file')}\"\n",
+    "    )\n",
+    "    print(f\"   {hit.document}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b64f0a75-c455-48f0-b0b7-381a33724397",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Inspect the Milvus collection\n",
+    "\n",
+    "MemPalace manages the Milvus schema for us. To confirm what was created, we can open the same Milvus Lite file with `MilvusClient` and inspect the collection directly.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "72fcd15f-c85c-4471-b593-a1c7d6a1ea4d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T08:43:08.974306Z",
+     "iopub.status.busy": "2026-07-23T08:43:08.974078Z",
+     "iopub.status.idle": "2026-07-23T08:43:09.009268Z",
+     "shell.execute_reply": "2026-07-23T08:43:09.008300Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collections: ['mempalace_drawers']\n",
+      "Collection stats: {'row_count': 8}\n",
+      "\n",
+      "Sample rows from Milvus:\n",
+      "- mem-001 room=architecture source=architecture-notes.md\n",
+      "- mem-002 room=deployment source=local-dev-runbook.md\n",
+      "- mem-003 room=deployment source=cloud-deployment.md\n",
+      "- mem-004 room=architecture source=storage-contract.md\n",
+      "- mem-005 room=evaluation source=evaluation-checklist.md\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pymilvus import MilvusClient\n",
+    "\n",
+    "collection.close()\n",
+    "\n",
+    "milvus_uri = str(palace_dir / \"milvus.db\")\n",
+    "client = MilvusClient(uri=milvus_uri)\n",
+    "client.load_collection(collection_name)\n",
+    "\n",
+    "print(\"Collections:\", client.list_collections())\n",
+    "print(\"Collection stats:\", client.get_collection_stats(collection_name))\n",
+    "\n",
+    "rows = client.query(\n",
+    "    collection_name=collection_name,\n",
+    "    filter=\"\",\n",
+    "    limit=5,\n",
+    "    output_fields=[\"id\", \"document\", \"metadata\"],\n",
+    ")\n",
+    "\n",
+    "print()\n",
+    "print(\"Sample rows from Milvus:\")\n",
+    "for row in rows:\n",
+    "    metadata = row.get(\"metadata\", {})\n",
+    "    print(\n",
+    "        f\"- {row['id']} room={metadata.get('room')} \"\n",
+    "        f\"source={metadata.get('source_file')}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68c33f87-a3b6-4f47-b2ee-f46d9587f7ff",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Optional: use Milvus server or Zilliz Cloud\n",
+    "\n",
+    "For a shared deployment, set the Milvus connection environment variables before opening the MemPalace collection. Leave them unset to use the local Milvus Lite file shown above.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "8f5fd038-16eb-4238-9af9-e2e7765d0a44",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-23T08:43:09.013950Z",
+     "iopub.status.busy": "2026-07-23T08:43:09.013632Z",
+     "iopub.status.idle": "2026-07-23T08:43:09.021800Z",
+     "shell.execute_reply": "2026-07-23T08:43:09.019896Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# os.environ[\"MEMPALACE_MILVUS_URI\"] = \"https://your-cluster.api.region.zillizcloud.com\"\n",
+    "# os.environ[\"MEMPALACE_MILVUS_TOKEN\"] = \"***********\"\n",
+    "# os.environ[\"MEMPALACE_MILVUS_DB_NAME\"] = \"default\"\n",
+    "# os.environ[\"MEMPALACE_MILVUS_NAMESPACE\"] = \"team-memory\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17fd9ad7-b9cb-4b7e-83b3-566e7f250efa",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Use the high-level MemPalace workflow\n",
+    "\n",
+    "For a real project, you usually do not need to hand-write the drawers as we did in the small Python example above. `mempalace init` inspects the project, proposes rooms from folder structure or filename patterns, and saves that taxonomy in `mempalace.yaml`. `mempalace mine` then scans readable project files, routes each chunk by path, filename, and content keywords, and stores the resulting drawers in the configured backend. For conversation exports, `--mode convos` normalizes chat history and routes it into topic rooms such as `technical`, `architecture`, `planning`, `decisions`, and `problems`.\n",
+    "\n",
+    "Use the same Milvus backend flag with those high-level commands:\n",
+    "\n",
+    "```shell\n",
+    "mempalace init /path/to/project --backend milvus --yes\n",
+    "mempalace mine /path/to/project --backend milvus\n",
+    "mempalace mine /path/to/conversations --mode convos --backend milvus --wing my_project\n",
+    "mempalace search \"How do we deploy memory?\" --backend milvus\n",
+    "```\n",
+    "\n",
+    "## Conclusion\n",
+    "\n",
+    "MemPalace gives agents a structured way to preserve project context: wings keep domains separate, rooms make memory scoping explicit, and drawers keep the original text available for retrieval. Milvus provides the storage and search layer behind that structure, combining vector search, metadata filtering, and lexical retrieval in one backend. Milvus Lite keeps the notebook simple, while the same integration path can scale to Milvus server or Zilliz Cloud when the memory layer needs to serve a team or a production agent workflow.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- Add a Google ADK notebook covering MilvusToolset retrieval and MilvusMemoryService cross-session memory.
- Add a MemPalace notebook covering Milvus backend setup, semantic and lexical search, metadata filtering, and collection inspection.
- Use Milvus Lite by default, with configuration notes for Milvus server and Zilliz Cloud.

## Validation

- Both notebooks pass nbformat validation.
- Both notebooks pass the Black notebook check.
- The Google ADK notebook has 10 successfully executed code cells with no error outputs.
- The MemPalace notebook has 9 successfully executed code cells with no error outputs.