### PR TITLE
Update Basic Memory Milvus installation

### DIFF
--- a/integration/basic_memory_with_milvus.md
+++ b/integration/basic_memory_with_milvus.md
@@ -27,14 +27,7 @@ You need:
 - A PostgreSQL database and its `postgresql+asyncpg://...` connection URL
 - An OpenAI API key
 
-Milvus support has been merged into Basic Memory but is not yet available in its current PyPI release. Until the next release is published, install the tested upstream commit that includes the Milvus restart fix:
-
-```bash
-uv tool install --python 3.12 \
-  "basic-memory[milvus] @ git+https://github.com/basicmachines-co/basic-memory.git@eedce9bb92750282ceec73f420bb6ef05e954d4c"
-```
-
-After Basic Memory publishes a release containing the integration, the installation can be simplified to:
+Install Basic Memory with its Milvus optional dependencies from PyPI:
 
 ```bash
 uv tool install --python 3.12 "basic-memory[milvus]"


### PR DESCRIPTION
## What changed

- Replace the temporary GitHub commit installation with the released PyPI package.
- Use the unpinned `basic-memory[milvus]` extra so readers install the current release.
- Remove the outdated pre-release guidance.

## Validation

- Confirmed Basic Memory v0.23.0 is available on PyPI with the `milvus` optional extra.
- Ran `git diff --check`.